### PR TITLE
feat(dstack): pin runtime RTMR3 events in verifier policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "atlas-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atlas-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "attested TLS (aTLS) core library for verifying TEE attestations over TLS connections"
 license = "MIT"

--- a/core/src/dstack/config.rs
+++ b/core/src/dstack/config.rs
@@ -1,6 +1,22 @@
 //! Configuration types for DStack TDX verification.
 
 use crate::tdx::ExpectedBootchain;
+use serde::{Deserialize, Serialize};
+
+/// A required runtime RTMR3 event and its expected (hex-encoded) payload.
+///
+/// dstack lets a guest extend RTMR3 at runtime with named events (e.g.
+/// `compose-hash`, or application-defined ones). This pins such an event by
+/// name: verification fails unless the (RTMR-replay-trusted) event log contains
+/// an event with this `event` name whose `event_payload` equals `payload`. The
+/// last occurrence wins, so a value re-emitted on rotation supersedes earlier ones.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeEventExpectation {
+    /// Event name as it appears in the dstack event log (e.g. `concrete-security-cvm`).
+    pub event: String,
+    /// Expected `event_payload`: lowercase hex of the extended payload bytes.
+    pub payload: String,
+}
 
 /// Configuration for DstackTDXVerifier.
 ///
@@ -41,6 +57,13 @@ pub struct DstackTDXVerifierConfig {
     /// The SHA256 hash of the OS image that should be running in the TD.
     pub os_image_hash: Option<String>,
 
+    /// Expected runtime RTMR3 events to pin (by name → payload).
+    ///
+    /// Empty by default. When non-empty, each entry must be present in the
+    /// (RTMR-replay-trusted) event log with a matching payload, in addition to
+    /// the standard bootchain/app_compose/os_image checks.
+    pub expected_runtime_events: Vec<RuntimeEventExpectation>,
+
     /// PCCS URL for collateral fetching.
     ///
     /// If None, uses Intel's default PCS endpoint.
@@ -62,6 +85,7 @@ impl Default for DstackTDXVerifierConfig {
             disable_runtime_verification: false,
             expected_bootchain: None,
             os_image_hash: None,
+            expected_runtime_events: Vec::new(),
             pccs_url: None,
             cache_collateral: true,
         }
@@ -127,6 +151,12 @@ impl DstackTDXVerifierBuilder {
     /// Set the expected OS image hash.
     pub fn os_image_hash(mut self, hash: impl Into<String>) -> Self {
         self.config.os_image_hash = Some(hash.into());
+        self
+    }
+
+    /// Set the expected runtime RTMR3 events to pin.
+    pub fn expected_runtime_events(mut self, events: Vec<RuntimeEventExpectation>) -> Self {
+        self.config.expected_runtime_events = events;
         self
     }
 

--- a/core/src/dstack/mod.rs
+++ b/core/src/dstack/mod.rs
@@ -9,7 +9,7 @@ pub mod default_app_compose;
 pub mod policy;
 mod verifier;
 
-pub use config::{DstackTDXVerifierBuilder, DstackTDXVerifierConfig};
+pub use config::{DstackTDXVerifierBuilder, DstackTDXVerifierConfig, RuntimeEventExpectation};
 pub use default_app_compose::{get_default_app_compose, merge_with_default_app_compose};
 pub use policy::DstackTdxPolicy;
 pub use verifier::DstackTDXVerifier;

--- a/core/src/dstack/policy.rs
+++ b/core/src/dstack/policy.rs
@@ -1,6 +1,6 @@
 //! DStack-specific policy types.
 
-use crate::dstack::{DstackTDXVerifier, DstackTDXVerifierBuilder};
+use crate::dstack::{DstackTDXVerifier, DstackTDXVerifierBuilder, RuntimeEventExpectation};
 use crate::tdx::{ExpectedBootchain, TCB_STATUS_LIST};
 use crate::verifier::IntoVerifier;
 use crate::AtlsVerificationError;
@@ -31,6 +31,13 @@ pub struct DstackTdxPolicy {
     /// Expected OS image hash (SHA256).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub os_image_hash: Option<String>,
+
+    /// Expected runtime RTMR3 events to pin (by name → hex payload).
+    ///
+    /// Empty by default (backward-compatible). When set, each named event must
+    /// appear in the RTMR-replay-trusted event log with a matching payload.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected_runtime_events: Vec<RuntimeEventExpectation>,
 
     /// Allowed TCB status values.
     #[serde(default = "default_allowed_tcb_status")]
@@ -67,6 +74,7 @@ impl Default for DstackTdxPolicy {
             expected_bootchain: None,
             app_compose: None,
             os_image_hash: None,
+            expected_runtime_events: Vec::new(),
             allowed_tcb_status: default_allowed_tcb_status(),
             grace_period: None,
             pccs_url: default_pccs_url(),
@@ -135,6 +143,27 @@ impl DstackTdxPolicy {
             }
         }
 
+        // Validate pinned runtime events
+        if self.disable_runtime_verification && !self.expected_runtime_events.is_empty() {
+            return Err(AtlsVerificationError::Configuration(
+                "expected_runtime_events cannot be set when disable_runtime_verification is true"
+                    .into(),
+            ));
+        }
+        for ev in &self.expected_runtime_events {
+            if ev.event.is_empty() {
+                return Err(AtlsVerificationError::Configuration(
+                    "expected_runtime_events entry has an empty event name".into(),
+                ));
+            }
+            if !is_valid_hex(&ev.payload) {
+                return Err(AtlsVerificationError::Configuration(format!(
+                    "expected_runtime_events payload for '{}' must be a lowercase hex string",
+                    ev.event
+                )));
+            }
+        }
+
         // Validate bootchain fields are hex
         if let Some(ref bootchain) = self.expected_bootchain {
             if !is_valid_hex(&bootchain.mrtd) {
@@ -186,6 +215,9 @@ impl IntoVerifier for DstackTdxPolicy {
         }
         if let Some(os_hash) = self.os_image_hash {
             builder = builder.os_image_hash(os_hash);
+        }
+        if !self.expected_runtime_events.is_empty() {
+            builder = builder.expected_runtime_events(self.expected_runtime_events);
         }
 
         builder = builder.allowed_tcb_status(self.allowed_tcb_status);
@@ -340,5 +372,76 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("mrtd"));
+    }
+
+    fn runtime_event(event: &str, payload: &str) -> RuntimeEventExpectation {
+        RuntimeEventExpectation {
+            event: event.into(),
+            payload: payload.into(),
+        }
+    }
+
+    #[test]
+    fn test_runtime_events_valid() {
+        let policy = DstackTdxPolicy {
+            expected_runtime_events: vec![runtime_event("concrete-security-cvm", "abcd1234")],
+            os_image_hash: Some("abcd".into()),
+            expected_bootchain: Some(ExpectedBootchain {
+                mrtd: "00".into(),
+                rtmr0: "00".into(),
+                rtmr1: "00".into(),
+                rtmr2: "00".into(),
+            }),
+            ..Default::default()
+        };
+        assert!(policy.validate().is_ok());
+    }
+
+    #[test]
+    fn test_runtime_events_invalid_hex_rejected() {
+        let policy = DstackTdxPolicy {
+            expected_runtime_events: vec![runtime_event("concrete-security-cvm", "not-hex!")],
+            disable_runtime_verification: false,
+            ..Default::default()
+        };
+        let err = policy.validate().unwrap_err().to_string();
+        assert!(err.contains("must be a lowercase hex string"));
+    }
+
+    #[test]
+    fn test_runtime_events_empty_name_rejected() {
+        let policy = DstackTdxPolicy {
+            expected_runtime_events: vec![runtime_event("", "abcd")],
+            ..Default::default()
+        };
+        let err = policy.validate().unwrap_err().to_string();
+        assert!(err.contains("empty event name"));
+    }
+
+    #[test]
+    fn test_runtime_events_conflict_with_disable_rejected() {
+        let policy = DstackTdxPolicy {
+            expected_runtime_events: vec![runtime_event("concrete-security-cvm", "abcd")],
+            disable_runtime_verification: true,
+            ..Default::default()
+        };
+        let err = policy.validate().unwrap_err().to_string();
+        assert!(err.contains("disable_runtime_verification"));
+    }
+
+    #[test]
+    fn test_runtime_events_json_roundtrip_and_default_empty() {
+        // Absent in JSON => empty (backward compatible).
+        let parsed: DstackTdxPolicy = serde_json::from_str("{}").unwrap();
+        assert!(parsed.expected_runtime_events.is_empty());
+
+        let policy = DstackTdxPolicy {
+            expected_runtime_events: vec![runtime_event("concrete-security-cvm", "abcd1234")],
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&policy).unwrap();
+        assert!(json.contains("expected_runtime_events"));
+        let back: DstackTdxPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.expected_runtime_events, policy.expected_runtime_events);
     }
 }

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -404,6 +404,42 @@ impl DstackTDXVerifier {
         Ok(())
     }
 
+    /// Verify pinned runtime RTMR3 events against the trusted event log.
+    ///
+    /// The event log integrity is guaranteed by RTMR replay verification against
+    /// the cryptographically verified report. For each expected event, the *last*
+    /// occurrence with a matching name must carry the expected payload (last wins,
+    /// so a value re-emitted on rotation supersedes earlier emissions).
+    fn verify_runtime_events(&self, events: &[EventLog]) -> Result<(), AtlsVerificationError> {
+        for expected in &self.config.expected_runtime_events {
+            debug!(
+                "Verifying runtime event '{}' against trusted event log",
+                expected.event
+            );
+            match events.iter().rfind(|e| e.event == expected.event) {
+                Some(event) if event.event_payload == expected.payload => {
+                    debug!("Runtime event '{}' matched", expected.event);
+                }
+                Some(event) => {
+                    return Err(AtlsVerificationError::RuntimeEventMismatch {
+                        event: expected.event.clone(),
+                        expected: expected.payload.clone(),
+                        actual: Some(event.event_payload.clone()),
+                    });
+                }
+                None => {
+                    return Err(AtlsVerificationError::RuntimeEventMismatch {
+                        event: expected.event.clone(),
+                        expected: expected.payload.clone(),
+                        actual: None,
+                    });
+                }
+            }
+        }
+        debug!("Runtime event verification successful");
+        Ok(())
+    }
+
     /// Verify RTMR replay using dstack-sdk's built-in replay_rtmrs().
     ///
     /// Compares replayed RTMRs from the event log against the trusted values
@@ -574,6 +610,9 @@ impl AtlsVerifier for DstackTDXVerifier {
         // 9. Verify OS image hash against trusted event log
         self.verify_os_image_hash(&events)?;
 
+        // 10. Verify pinned runtime RTMR3 events against trusted event log
+        self.verify_runtime_events(&events)?;
+
         debug!("DStack TDX verification complete");
         Ok(Report::Tdx(verified_report))
     }
@@ -682,4 +721,118 @@ fn parse_content_length(headers: &[u8]) -> Option<usize> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dstack::config::{DstackTDXVerifierConfig, RuntimeEventExpectation};
+    use crate::error::AtlsVerificationError;
+
+    fn event(name: &str, payload: &str) -> EventLog {
+        EventLog {
+            imr: 3,
+            event_type: 0x0800_0001,
+            digest: "00".repeat(48),
+            event: name.to_string(),
+            event_payload: payload.to_string(),
+        }
+    }
+
+    fn verifier_with(expected: Vec<RuntimeEventExpectation>) -> DstackTDXVerifier {
+        // disable_runtime_verification lets us build a verifier without the
+        // bootchain/app_compose/os_image fields; we test verify_runtime_events directly.
+        DstackTDXVerifier::new(DstackTDXVerifierConfig {
+            disable_runtime_verification: true,
+            expected_runtime_events: expected,
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    fn expect(event: &str, payload: &str) -> RuntimeEventExpectation {
+        RuntimeEventExpectation {
+            event: event.to_string(),
+            payload: payload.to_string(),
+        }
+    }
+
+    #[test]
+    fn runtime_event_present_and_matching_passes() {
+        let v = verifier_with(vec![expect("concrete-security-cvm", "abcd")]);
+        let events = vec![
+            event("compose-hash", "ffff"),
+            event("concrete-security-cvm", "abcd"),
+        ];
+        assert!(v.verify_runtime_events(&events).is_ok());
+    }
+
+    #[test]
+    fn runtime_event_missing_fails() {
+        let v = verifier_with(vec![expect("concrete-security-cvm", "abcd")]);
+        let events = vec![event("compose-hash", "ffff")];
+        let err = v.verify_runtime_events(&events).unwrap_err();
+        assert!(matches!(
+            err,
+            AtlsVerificationError::RuntimeEventMismatch { actual: None, .. }
+        ));
+    }
+
+    #[test]
+    fn runtime_event_wrong_payload_fails() {
+        let v = verifier_with(vec![expect("concrete-security-cvm", "abcd")]);
+        let events = vec![event("concrete-security-cvm", "dead")];
+        let err = v.verify_runtime_events(&events).unwrap_err();
+        match err {
+            AtlsVerificationError::RuntimeEventMismatch {
+                actual: Some(a),
+                expected,
+                ..
+            } => {
+                assert_eq!(a, "dead");
+                assert_eq!(expected, "abcd");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn runtime_event_last_occurrence_wins() {
+        let v = verifier_with(vec![expect("concrete-security-cvm", "newv")]);
+        // An old value followed by the rotated value: last wins => passes.
+        let events = vec![
+            event("concrete-security-cvm", "oldv"),
+            event("concrete-security-cvm", "newv"),
+        ];
+        assert!(v.verify_runtime_events(&events).is_ok());
+
+        // If the latest no longer matches the pinned value, it must fail.
+        let stale = verifier_with(vec![expect("concrete-security-cvm", "oldv")]);
+        assert!(stale.verify_runtime_events(&events).is_err());
+    }
+
+    #[test]
+    fn multiple_expected_events_all_required() {
+        let v = verifier_with(vec![
+            expect("concrete-dev-binding", "1111"),
+            expect("concrete-security-cvm", "2222"),
+        ]);
+        let ok = vec![
+            event("concrete-dev-binding", "1111"),
+            event("concrete-security-cvm", "2222"),
+        ];
+        assert!(v.verify_runtime_events(&ok).is_ok());
+
+        let missing_one = vec![event("concrete-dev-binding", "1111")];
+        assert!(v.verify_runtime_events(&missing_one).is_err());
+    }
+
+    #[test]
+    fn no_expected_events_is_noop() {
+        let v = verifier_with(vec![]);
+        assert!(v.verify_runtime_events(&[]).is_ok());
+        assert!(v
+            .verify_runtime_events(&[event("compose-hash", "ffff")])
+            .is_ok());
+    }
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -52,6 +52,14 @@ pub enum AtlsVerificationError {
         actual: Option<String>,
     },
 
+    /// A pinned runtime RTMR3 event was missing or carried an unexpected payload.
+    #[error("runtime event '{event}' mismatch: expected {expected}, got {actual:?}")]
+    RuntimeEventMismatch {
+        event: String,
+        expected: String,
+        actual: Option<String>,
+    },
+
     /// TCB status not in allowed list.
     #[error("TCB status {status} not allowed (allowed: {allowed:?})")]
     TcbStatusNotAllowed { status: String, allowed: Vec<String> },


### PR DESCRIPTION
Add `expected_runtime_events` to DstackTdxPolicy/DstackTDXVerifierConfig and a verify_runtime_events step that requires each named RTMR3 event to be present in the (replay-trusted) event log with a matching payload. The last occurrence wins, so a value re-emitted at runtime (e.g. on rotation) supersedes earlier emissions.

Backward compatible: the field defaults empty, is skipped when unset, and is rejected together with disable_runtime_verification. This lets consumers pin application-defined runtime measurements the same way compose-hash and os-image-hash are already pinned.

This is required for the dynamic atlas_policy between the dev and security CVMs. Related to https://github.com/concrete-security/concrete/issues/13