### PR TITLE
feat(core): independent SNI routing + release atlas-rs 0.3.0

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atlas-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "attested TLS (aTLS) core library for verifying TEE attestations over TLS connections"
 license = "MIT"

--- a/core/src/connect.rs
+++ b/core/src/connect.rs
@@ -9,8 +9,12 @@ use crate::error::AtlsVerificationError;
 use crate::policy::Policy;
 use crate::verifier::{AsyncByteStream, Report};
 use crate::AtlsVerifier;
-use rustls::pki_types::ServerName;
-use rustls::{ClientConfig, RootCertStore};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::client::WebPkiServerVerifier;
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{
+    ClientConfig, DigitallySignedStruct, Error as RustlsError, RootCertStore, SignatureScheme,
+};
 use std::sync::Arc;
 
 // Platform-specific TLS types
@@ -47,13 +51,50 @@ pub async fn tls_handshake<S>(
 where
     S: AsyncByteStream + 'static,
 {
-    debug!("Starting TLS handshake to {}", server_name);
+    tls_handshake_with_cert_name(stream, server_name, server_name, alpn).await
+}
+
+/// Perform TLS handshake with independent SNI routing and certificate identity.
+///
+/// `route_server_name` is sent as TLS SNI so an ingress gateway can route the
+/// connection. `cert_server_name` is still used for normal WebPKI hostname
+/// validation against the presented certificate.
+///
+/// Crate-internal: callers outside the crate should use the high-level
+/// [`atls_connect_with_route_sni`].
+pub(crate) async fn tls_handshake_with_cert_name<S>(
+    stream: S,
+    route_server_name: &str,
+    cert_server_name: &str,
+    alpn: Option<Vec<String>>,
+) -> Result<(TlsStream<S>, Vec<u8>, Vec<u8>), AtlsVerificationError>
+where
+    S: AsyncByteStream + 'static,
+{
+    debug!(
+        "Starting TLS handshake to {} with certificate identity {}",
+        route_server_name, cert_server_name
+    );
 
     let mut root_store = RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
+    let cert_name = ServerName::try_from(cert_server_name.to_owned())
+        .map_err(|e| AtlsVerificationError::InvalidServerName(e.to_string()))?;
+    let verifier = WebPkiServerVerifier::builder(Arc::new(root_store))
+        .build()
+        .map_err(|e| {
+            AtlsVerificationError::TlsHandshake(format!(
+                "Failed to build certificate verifier: {}",
+                e
+            ))
+        })?;
     let mut config = ClientConfig::builder()
-        .with_root_certificates(root_store)
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(CertificateNameVerifier {
+            inner: verifier,
+            cert_name,
+        }))
         .with_no_client_auth();
 
     if let Some(protocols) = alpn {
@@ -61,7 +102,7 @@ where
     }
 
     let connector = TlsConnector::from(Arc::new(config));
-    let server_name_parsed = ServerName::try_from(server_name.to_owned())
+    let server_name_parsed = ServerName::try_from(route_server_name.to_owned())
         .map_err(|e| AtlsVerificationError::InvalidServerName(e.to_string()))?;
 
     let tls_stream = connector
@@ -92,6 +133,53 @@ where
     debug!("Session EKM extracted ({} bytes)", session_ekm.len());
 
     Ok((tls_stream, peer_cert, session_ekm))
+}
+
+#[derive(Debug)]
+struct CertificateNameVerifier {
+    inner: Arc<dyn ServerCertVerifier>,
+    cert_name: ServerName<'static>,
+}
+
+impl ServerCertVerifier for CertificateNameVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        self.inner.verify_server_cert(
+            end_entity,
+            intermediates,
+            &self.cert_name,
+            ocsp_response,
+            now,
+        )
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        self.inner.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        self.inner.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.inner.supported_verify_schemes()
+    }
 }
 
 /// Establish a TLS connection with attestation verification.
@@ -154,4 +242,123 @@ where
     debug!("Attestation verification successful");
 
     Ok((tls_stream, report))
+}
+
+/// Establish a TLS connection with independent SNI routing and attestation verification.
+///
+/// `server_name` remains the certificate and attestation identity. `route_server_name`
+/// is used only for the TLS SNI value required by some ingress gateways.
+pub async fn atls_connect_with_route_sni<S>(
+    stream: S,
+    server_name: &str,
+    route_server_name: &str,
+    policy: Policy,
+    alpn: Option<Vec<String>>,
+) -> Result<(TlsStream<S>, Report), AtlsVerificationError>
+where
+    S: AsyncByteStream + 'static,
+{
+    crate::logging::init();
+
+    let (mut tls_stream, peer_cert, session_ekm) =
+        tls_handshake_with_cert_name(stream, route_server_name, server_name, alpn).await?;
+
+    debug!("Starting attestation verification");
+    let verifier = policy.into_verifier()?;
+    let report = verifier
+        .verify(&mut tls_stream, &peer_cert, &session_ekm, server_name)
+        .await?;
+
+    debug!("Attestation verification successful");
+
+    Ok((tls_stream, report))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Inner verifier stub that records the `server_name` it is handed and
+    /// otherwise approves everything, so a test can observe which identity the
+    /// wrapping verifier forwarded.
+    #[derive(Debug)]
+    struct RecordingVerifier {
+        seen_name: Mutex<Option<ServerName<'static>>>,
+    }
+
+    impl ServerCertVerifier for RecordingVerifier {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            server_name: &ServerName<'_>,
+            _ocsp_response: &[u8],
+            _now: UnixTime,
+        ) -> Result<ServerCertVerified, RustlsError> {
+            *self.seen_name.lock().unwrap() = Some(server_name.to_owned());
+            Ok(ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, RustlsError> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, RustlsError> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            vec![SignatureScheme::ED25519]
+        }
+    }
+
+    /// Regression test for independent SNI routing: `CertificateNameVerifier`
+    /// must verify the certificate against `cert_name` (the attestation/cert
+    /// identity) and never leak the routed SNI to the inner verifier.
+    #[test]
+    fn certificate_name_verifier_uses_cert_name_not_routed_sni() {
+        let recorder = Arc::new(RecordingVerifier {
+            seen_name: Mutex::new(None),
+        });
+        let cert_name = ServerName::try_from("cert.example.com").unwrap();
+        let routed_sni = ServerName::try_from("gateway.route.example").unwrap();
+
+        let verifier = CertificateNameVerifier {
+            inner: recorder.clone(),
+            cert_name: cert_name.clone(),
+        };
+
+        let dummy_cert = CertificateDer::from(vec![0u8; 4]);
+        let result = verifier.verify_server_cert(
+            &dummy_cert,
+            &[],
+            &routed_sni,
+            &[],
+            UnixTime::since_unix_epoch(std::time::Duration::from_secs(0)),
+        );
+        assert!(result.is_ok());
+
+        let seen = recorder.seen_name.lock().unwrap().clone();
+        assert_eq!(
+            seen,
+            Some(cert_name),
+            "inner verifier must receive cert_server_name"
+        );
+        assert_ne!(
+            seen,
+            Some(routed_sni),
+            "routed SNI must never reach the inner verifier"
+        );
+    }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -90,12 +90,14 @@ pub mod tdx;
 pub mod verifier;
 
 // High-level API
-pub use connect::{atls_connect, TlsStream};
+pub use connect::{atls_connect, atls_connect_with_route_sni, TlsStream};
 pub use policy::Policy;
 
 // Dstack-specific (backward compatible re-exports)
 // NOTE: compose_hash NOT exposed at root - access via dstack::compose_hash
-pub use dstack::{DstackTDXVerifier, DstackTDXVerifierBuilder, DstackTDXVerifierConfig, DstackTdxPolicy};
+pub use dstack::{
+    DstackTDXVerifier, DstackTDXVerifierBuilder, DstackTDXVerifierConfig, DstackTdxPolicy,
+};
 
 // Generic TDX
 pub use tdx::{ExpectedBootchain, TCB_STATUS_LIST};
@@ -103,8 +105,8 @@ pub use tdx::{ExpectedBootchain, TCB_STATUS_LIST};
 // Low-level API
 pub use error::AtlsVerificationError;
 pub use verifier::{
-    AsyncByteStream, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, IntoVerifier, AtlsVerifier,
-    Report, Verifier,
+    AsyncByteStream, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, AtlsVerifier,
+    IntoVerifier, Report, Verifier,
 };
 
 // Re-export VerifiedReport from dcap-qvl for bindings


### PR DESCRIPTION
## What

- Add **`atls_connect_with_route_sni`** to the core crate: send one hostname as the TLS **SNI** value — for ingress/gateway routing — while verifying the server certificate and attestation against a **different** identity. A `CertificateNameVerifier` wraps the WebPKI verifier so the leaf cert is checked against the attestation identity (`cert_server_name`), not the routed SNI (`route_server_name`).
- Keep the public surface minimal: `atls_connect_with_route_sni` is the entry point; the underlying `tls_handshake_with_cert_name` is `pub(crate)`.
- **Bump `atlas-rs` to `0.3.0`** so a release captures both this new API and the previously-committed-but-unpublished TCB grace-period handling (landed in `f74a6a2`, never published — crates.io is still at `0.2.0`).

## Why

The Console-side attestation verifier (in the `concrete` repo) depends on `atls_connect_with_route_sni` and drives it in production via `connect_host`/`passthrough_host` (gateway-routed egress). That symbol does not exist in the published `atlas-rs 0.2.0`, so the verifier currently can only be built against an **unpublished, uncommitted** working tree on one host — it can't be rebuilt or deployed elsewhere. Publishing `0.3.0` lets `concrete` depend on the crate from crates.io instead of vendoring or relying on local state.

## Scope

Deliberately focused on the publishable feature + version bump:
- `core/src/connect.rs` — route-SNI API + regression test
- `core/src/lib.rs` — export
- `core/Cargo.toml` — `0.2.0` → `0.3.0`

Pre-existing `cargo fmt` drift on `main` (grace-period files) and the binding (`node`/`python`/`wasm`) changes are intentionally **not** included here.

## Validation

- `cargo build -p atlas-rs` ✓
- `cargo clippy -p atlas-rs` ✓ (2 non-blocking warnings, pre-existing)
- `cargo fmt` leaves `connect.rs`/`lib.rs` untouched (drift is pre-existing elsewhere on `main`)
- **Regression test** `certificate_name_verifier_uses_cert_name_not_routed_sni` ✓ — asserts `CertificateNameVerifier` forwards `cert_server_name` (not the routed SNI) to the inner verifier
- Live-endpoint integration tests fail only because no attested TDX peer is reachable from the build sandbox (same on `main`; unchanged by this PR)

## Follow-ups

- After merge: run **`publish-core.yml`** (`workflow_dispatch`, `dry_run=false`) to publish `atlas-rs 0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)