### PR TITLE
docs(node) + test: fix README examples and unblock CI (skip decommissioned-enclave tests)

### DIFF
--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -206,6 +206,7 @@ mod integration {
     /// Test verifier with runtime verification disabled.
     /// This is the simplest test - it only verifies DCAP quote and RTMR replay.
     #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_verifier_disabled_runtime_verification() {
         let verifier = DstackTDXVerifierBuilder::new()
             .disable_runtime_verification()
@@ -237,6 +238,7 @@ mod integration {
 
     /// Test that a policy with grace_period set still verifies when the platform is not OutOfDate.
     #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_policy_grace_period_allows_non_outofdate() {
         let tcp = tokio::net::TcpStream::connect(format!("{}:443", TEST_HOST))
             .await
@@ -262,6 +264,7 @@ mod integration {
 
     /// Test grace period behavior by forcing an OutOfDate status on a real quote.
     #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_grace_period_outofdate_paths() {
         let mut nonce = [0u8; 32];
         rand::Rng::fill(&mut rand::thread_rng(), &mut nonce);
@@ -323,6 +326,7 @@ mod integration {
     /// Test verifier with bootchain verification.
     /// This verifies DCAP quote, RTMR replay, and bootchain measurements.
     #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_verifier_bootchain_verification() {
         // Use a minimal app_compose just to satisfy the builder
         // We won't actually verify it matches since we don't know the exact compose
@@ -363,6 +367,7 @@ mod integration {
 
     /// Test that verifier fails with wrong bootchain measurements.
     #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_verifier_wrong_bootchain_fails() {
         let wrong_bootchain = ExpectedBootchain {
             mrtd: "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string(),
@@ -403,6 +408,7 @@ mod integration {
     /// docker-compose file that matches the server, this test actually verifies that some
     /// verification fails. We use disable_runtime_verification to test OS hash in isolation.
     #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_verifier_fails_with_wrong_config() {
         let wrong_os_hash = "0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -441,6 +447,7 @@ mod integration {
 
     /// Test multiple verifications with the same verifier instance.
     #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_verifier_multiple_connections() {
         let verifier = DstackTDXVerifierBuilder::new()
             .disable_runtime_verification()
@@ -467,6 +474,7 @@ mod integration {
 
     /// Test that collateral caching works correctly across multiple verifications.
     #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_collateral_caching() {
         let verifier = DstackTDXVerifierBuilder::new()
             .disable_runtime_verification()
@@ -494,6 +502,7 @@ mod integration {
     /// Test using the async verifier from synchronous code.
     /// This demonstrates how to use the async API with a blocking runtime wrapper.
     #[test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     fn test_verifier_sync_wrapper() {
         // Ensure crypto provider is installed
         ensure_crypto_provider();
@@ -528,6 +537,7 @@ mod integration {
 
     /// Test the high-level atls_connect API with full verification policy.
     #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_atls_connect_full_verification() {
         let tcp = tokio::net::TcpStream::connect(format!("{}:443", TEST_HOST))
             .await
@@ -567,6 +577,7 @@ mod integration {
 
     /// Test atls_connect with ALPN protocols and full verification.
     #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_atls_connect_with_alpn() {
         let tcp = tokio::net::TcpStream::connect(format!("{}:443", TEST_HOST))
             .await
@@ -610,6 +621,7 @@ mod integration {
 
     /// Test tls_handshake separately.
     #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_tls_handshake_only() {
         let tcp = tokio::net::TcpStream::connect(format!("{}:443", TEST_HOST))
             .await

--- a/node/README.md
+++ b/node/README.md
@@ -20,7 +20,8 @@ Prebuilt binaries are included for:
 ```typescript
 import { createAtlsFetch } from "@concrete-security/atlas-node"
 
-const fetch = createAtlsFetch("enclave.example.com")
+// `policy` is required — see "Policy Configuration" below.
+const fetch = createAtlsFetch({ target: "enclave.example.com", policy })
 const response = await fetch("/api/secure-data")
 
 console.log(response.attestation.trusted)  // true
@@ -38,6 +39,7 @@ import { streamText } from "ai"
 
 const fetch = createAtlsFetch({
   target: "enclave.example.com",
+  policy,  // required — see "Policy Configuration" below
   onAttestation: (att) => console.log(`TEE verified: ${att.teeType}`)
 })
 
@@ -62,23 +64,15 @@ for await (const chunk of textStream) {
 
 ## API
 
-### `createAtlsFetch(target)`
-
-Create an attested fetch function with a simple target string:
-
-```typescript
-const fetch = createAtlsFetch("enclave.example.com")
-// or with port
-const fetch = createAtlsFetch("enclave.example.com:8443")
-```
-
 ### `createAtlsFetch(options)`
 
-Create with full configuration:
+`createAtlsFetch` takes an options object; `target` and `policy` are required.
+(The string shorthand `createAtlsFetch("host")` is no longer supported.)
 
 ```typescript
 const fetch = createAtlsFetch({
   target: "enclave.example.com",      // Required: host with optional port
+  policy,                             // Required: verification policy (see "Policy Configuration")
   serverName: "enclave.example.com",  // Optional: SNI override
   headers: { "X-Custom": "value" },   // Optional: default headers
   onAttestation: (attestation) => {   // Optional: attestation callback
@@ -101,6 +95,7 @@ import https from "https"
 
 const agent = createAtlsAgent({
   target: "enclave.example.com",
+  policy,  // required — see "Policy Configuration" below
   onAttestation: (att) => console.log("Verified:", att.teeType)
 })
 
@@ -258,7 +253,7 @@ Full TypeScript definitions are included:
 ```typescript
 import { createAtlsFetch, AtlsFetch, AtlsAttestation, AtlsResponse } from "@concrete-security/atlas-node"
 
-const fetch: AtlsFetch = createAtlsFetch("enclave.example.com")
+const fetch: AtlsFetch = createAtlsFetch({ target: "enclave.example.com", policy })
 
 const response: AtlsResponse = await fetch("/api")
 const attestation: AtlsAttestation = response.attestation

--- a/node/test.mjs
+++ b/node/test.mjs
@@ -48,6 +48,7 @@ const DEV_POLICY = {
 // Test helpers
 let passed = 0
 let failed = 0
+let skipped = 0
 
 function test(name, fn) {
   return async () => {
@@ -61,6 +62,12 @@ function test(name, fn) {
       failed++
     }
   }
+}
+
+// Skip a test without removing it (e.g. it needs a live endpoint). Mirrors Rust's #[ignore].
+test.skip = (name, _fn) => async () => {
+  console.log(`⊘ ${name} (skipped)`)
+  skipped++
 }
 
 function assert(condition, message) {
@@ -258,7 +265,9 @@ const tests = [
     assert(typeof mainExports.mergeWithDefaultAppCompose === "function", "mergeWithDefaultAppCompose not exported")
   }),
 
-  test("full verification against vllm.concrete-security.com", async () => {
+  // Skipped: live enclave vllm.concrete-security.com decommissioned. Repoint to a
+  // new endpoint or convert to offline fixtures to re-enable.
+  test.skip("full verification against vllm.concrete-security.com", async () => {
     const fetch = createAtlsFetch({
       target: "vllm.concrete-security.com",
       policy: VLLM_POLICY,
@@ -293,7 +302,7 @@ async function main() {
   }
 
   console.log("\n================================")
-  console.log(`Results: ${passed} passed, ${failed} failed`)
+  console.log(`Results: ${passed} passed, ${failed} failed, ${skipped} skipped`)
 
   // Gracefully close all sockets before exiting
   await binding.closeAllSockets()


### PR DESCRIPTION
Two related fixes surfaced while checking the Node docs against source.

## 1. Docs: README examples that throw at runtime

The Node README documented `createAtlsFetch` / `createAtlsAgent` usages that **throw at runtime** — the string shorthand was removed and `policy` made mandatory, but the docs weren't updated. `atls-fetch.js` rejects both forms explicitly:

```js
if (typeof options === "string")  throw new Error("String shorthand no longer supported - policy is required. Use: { target, policy }")
if (!options.policy)              throw new Error("policy is required for aTLS verification. ...")
```

Fixed: all examples now use the required `{ target, policy }` form; removed the dead `createAtlsFetch(target)` subsection. (The node test suite already asserts this runtime behavior — "requires policy" / "rejects string shorthand".)

## 2. CI: skip tests against the decommissioned enclave

CI has been red on every PR since ~June (last green was March). Root cause: the `core` integration tests and one `node` test connect to a live enclave, **`vllm.concrete-security.com`, which is now decommissioned** — every connection dies with `tls handshake eof`. (Unit/wasm/python/proxy jobs were always green.)

Fixed by skipping just the live-host tests so CI reflects code correctness:
- `core/tests/integration_test.rs`: `#[ignore]` on the 12 live-enclave tests (kept compiling, just not run).
- `node/test.mjs`: added a `test.skip` helper (mirrors `#[ignore]`) and skipped the one `vllm` verification test.

Verified locally (endpoint is dead, so this reproduces CI):
- core: `6 passed; 0 failed; 12 ignored`
- node: `18 passed, 0 failed, 1 skipped`

### Follow-up (not in this PR)
The skipped tests need to be **repointed at a new endpoint or converted to offline fixtures** (recorded quote + collateral, mocked clock) to restore full-verification coverage. Also minor doc nits spotted but not fixed here: `app_compose.runner` (undocumented field) and `teeType: "sgx"` (only TDX supported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)