### PR TITLE
feat(core): safe self-signed cert acceptance + RTMR3 enforcement (0.3.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
         run: cargo check -p atlas-wasm --target wasm32-unknown-unknown
       - name: Run WASM tests (Node.js)
         run: wasm-pack test --node wasm
+      - name: Run WASM wrapper tests
+        working-directory: wasm
+        run: npm test
 
   test-node:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ cd python && make qa-all
 
 # Full verification (closest CI parity)
 make test-all
-make test-wasm-node
+make test-wasm-node # Rust/WASM and JS wrapper tests in Node.js
 
 # Build outputs
 make build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "atlas-rs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "atlas-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async_io_stream",
  "atlas-rs",

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 	@echo "  make test           # run native Rust tests (core, proxy)"
 	@echo "  make test-proxy     # run proxy unit and integration tests"
 	@echo "  make test-wasm      # cargo check atlas-wasm for wasm32 target"
-	@echo "  make test-wasm-node # run WASM tests in Node.js via wasm-pack"
+	@echo "  make test-wasm-node # run Rust/WASM and JS wrapper tests in Node.js"
 	@echo "  make test-node      # run Node.js binding tests"
 	@echo "  make test-private-ai-sdk # run AI provider package tests"
 	@echo "  make test-python    # run Python binding tests"
@@ -40,6 +40,7 @@ test-wasm:
 # Run WASM tests in Node.js via wasm-pack
 test-wasm-node:
 	wasm-pack test --node wasm
+	cd wasm && npm test
 
 # Node.js binding tests
 test-node:

--- a/core/ARCHITECTURE.md
+++ b/core/ARCHITECTURE.md
@@ -24,9 +24,10 @@ aTLS (attested TLS) enables clients to verify that a TLS server is running insid
 │                       High-Level API                            │
 │    atls_connect(stream, server_name, policy, alpn)            │
 │                                                                 │
-│    1. TLS handshake with CA verification                       │
-│    2. Capture peer certificate                                  │
-│    3. Convert policy to verifier                                │
+│    1. Convert policy to verifier                                │
+│    2. TLS handshake with CA verification, or explicit           │
+│       self-signed mode requiring RTMR3 instance pinning          │
+│    3. Capture peer certificate and session EKM                  │
 │    4. Run attestation verification                              │
 │    5. Return (TlsStream, Report)                                │
 └─────────────────────────────────────────────────────────────────┘
@@ -46,7 +47,7 @@ aTLS (attested TLS) enables clients to verify that a TLS server is running insid
 ┌─────────────────────────────────────────────────────────────────┐
 │                         Verifier                                │
 │  ┌─────────────────────┐                                       │
-│  │ DstackTDXVerifier   │─────▶ verify(stream, cert, hostname)  │
+│  │ DstackTDXVerifier   │────▶ verify(stream, cert, ekm, host)  │
 │  │ (+ future verifiers)│                                       │
 │  └─────────────────────┘                                       │
 │                                                                 │
@@ -78,6 +79,7 @@ pub trait AtlsVerifier: Send + Sync {
         &self,
         stream: &mut S,       // TLS stream for quote fetching
         peer_cert: &[u8],     // Server's TLS certificate (DER)
+        session_ekm: &[u8],   // TLS exporter binding this session
         hostname: &str,       // Server hostname
     ) -> impl Future<Output = Result<Report, AtlsVerificationError>> + Send
     where
@@ -136,14 +138,18 @@ pub enum Report {
 
 When `atls_connect()` is called:
 
-1. **TLS Handshake** - Establish TLS connection using webpki-roots CA bundle
-2. **Certificate Capture** - Extract server's leaf certificate (DER-encoded)
-3. **Policy → Verifier** - Call `policy.into_verifier()` to create the verifier
-4. **Attestation** - Call `verifier.verify(stream, cert, hostname)`:
+1. **Policy → Verifier** - Call `policy.into_verifier()` before the handshake so
+   invalid policy cannot enable a weaker TLS verifier
+2. **TLS Handshake** - Establish TLS connection using webpki-roots CA bundle by
+   default, or explicit self-signed mode when the policy includes an
+   `expected_rtmr3` instance pin
+3. **Certificate and EKM Capture** - Extract server's leaf certificate
+   (DER-encoded) and session Exported Keying Material
+4. **Attestation** - Call `verifier.verify(stream, cert, session_ekm, hostname)`:
    - Fetch attestation quote from server (e.g., HTTP POST to `/tdx_quote`)
    - Verify quote cryptographically (e.g., Intel DCAP verification)
-   - Verify certificate binding (cert hash in event log)
-   - Verify measurements (bootchain, app config, OS image)
+   - Verify certificate binding from authenticated RTMR3 dstack runtime events
+   - Verify RTMR replay, bootchain, app config, OS image, and optional RTMR3 pin
 5. **Return** - Return `(TlsStream, Report)` for continued communication
 
 ## Module Structure

--- a/core/BOOTCHAIN-VERIFICATION.md
+++ b/core/BOOTCHAIN-VERIFICATION.md
@@ -24,12 +24,12 @@ The verification covers the full boot process through TDX measurement registers:
 
 The complete verification flow is:
 
-1. **TLS Certificate Verification** - Certificate hash in event log matches the connection
+1. **TLS Certificate Verification** - Certificate hash in authenticated RTMR3 dstack runtime events matches the connection
 2. **DCAP Quote Verification** - Quote signature is valid and TCB status is acceptable
 3. **Bootchain Verification** - MRTD and RTMR0-2 match expected values
-4. **RTMR Replay Verification** - Event log correctly produces all RTMRs
-5. **App Compose Verification** - Application configuration matches expected
-6. **OS Image Hash Verification** - OS image hash in event log matches expected
+4. **RTMR Replay Verification** - Event log correctly produces all RTMRs, and unsupported IMR indexes are rejected
+5. **App Compose Verification** - Application configuration matches expected RTMR3 runtime event
+6. **OS Image Hash Verification** - OS image hash in RTMR3 runtime event matches expected
 
 ## How to Use
 
@@ -79,6 +79,12 @@ See the [Computing Measurements](#computing-measurements-for-new-dstack-versions
 - To skip runtime verification, you must explicitly set `disable_runtime_verification: true` in the policy
 - **`DstackTdxPolicy::dev()`** sets `disable_runtime_verification: true` for development convenience
 - Disabling runtime verification is **NOT recommended** for production use
+- `accept_self_signed_certs` requires `expected_rtmr3` and cannot be combined with
+  `disable_runtime_verification`; without hostname validation, RTMR3 is the
+  per-instance endpoint binding
+- Atlas trusts app compose, OS image, and TLS certificate payloads only from
+  authenticated RTMR3 dstack runtime events. Same-name events in IMR0-2, IMR4+,
+  or another event namespace are not used for these decisions.
 
 ## Computing Measurements for New Dstack Versions
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atlas-rs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "attested TLS (aTLS) core library for verifying TEE attestations over TLS connections"
 license = "MIT"

--- a/core/README.md
+++ b/core/README.md
@@ -183,14 +183,22 @@ Policy fields vary by verifier implementation. The `Policy` enum wraps implement
 | `expected_bootchain` | MRTD and RTMR0-2 measurements | Yes (unless disabled) |
 | `os_image_hash` | SHA256 of Dstack image's sha256sum.txt | Yes (unless disabled) |
 | `app_compose` | Expected application configuration | Yes (unless disabled) |
+| `expected_rtmr3` | Full RTMR3 runtime measurement, as 96 lowercase hex chars. Required with `accept_self_signed_certs`; optional otherwise. | No |
 | `allowed_tcb_status` | Acceptable TCB statuses (e.g., `["UpToDate"]`) | Yes |
 | `grace_period` | Grace period (seconds) for `OutOfDate` TCB status. `0` means no grace window. | No |
 | `disable_runtime_verification` | Skip runtime checks (default: false) | No |
+| `accept_self_signed_certs` | Skip CA-chain, hostname/SAN, and expiry validation for TEE self-signed certificates. Requires `expected_rtmr3` and cannot be combined with `disable_runtime_verification`. | No |
 | `pccs_url` | Intel PCCS URL (defaults to Phala's) | No |
 | `cache_collateral` | Cache Intel collateral (default: false) | No |
 
 Time-based TCB checks:
 - `grace_period` applies only when the TCB status is `OutOfDate` and requires `OutOfDate` in `allowed_tcb_status`. A value of `0` means no grace window.
+
+Self-signed certificate mode is fail closed. Enabling `accept_self_signed_certs`
+without `expected_rtmr3`, or together with `disable_runtime_verification`, is a
+configuration error. Removing hostname validation otherwise allows a different
+genuine TEE running the same approved workload to impersonate the intended
+endpoint.
 
 ```rust
 use atlas_rs::{Policy, DstackTdxPolicy, ExpectedBootchain};
@@ -213,10 +221,14 @@ let prod_policy = Policy::DstackTdx(DstackTdxPolicy {
         "runner": "docker-compose",
         "docker_compose_file": "..."
     })),
+    expected_rtmr3: Some("1f2e3d4c...".into()),
     allowed_tcb_status: vec!["UpToDate".into()],
     grace_period: Some(30 * 24 * 60 * 60),
     ..Default::default()
 });
+
+// For TEE self-signed certificates, use the same production measurements and
+// also set accept_self_signed_certs: true. That mode requires expected_rtmr3.
 
 // This will FAIL - missing runtime fields without disable_runtime_verification
 let invalid_policy = Policy::DstackTdx(DstackTdxPolicy::default());
@@ -279,7 +291,11 @@ Since the EKM is derived from the TLS session's master secret (unique per sessio
 
 ### Step 1: TLS Handshake
 
-TLS 1.3 handshake with a promiscuous verifier. The certificate is accepted temporarily and recorded for later verification.
+By default, the TLS 1.3 handshake uses standard webpki-roots CA validation and
+hostname/SAN checks. TEE self-signed certificates require an explicit
+`accept_self_signed_certs` policy and a mandatory `expected_rtmr3` pin, which
+replaces hostname identity with a measured per-instance identity. In both modes,
+Atlas records the negotiated leaf certificate for attestation verification.
 
 ### Step 2: EKM Extraction & Quote Retrieval
 
@@ -327,9 +343,9 @@ Server responds:
 
 1. Validate the quote signature using Intel PCCS collateral (DCAP verification flow)
 2. Ensure `report_data` in the quote equals `SHA512(nonce || session_ekm)` (session binding + freshness)
-3. Recompute RTMR3 by replaying every event log entry in order and ensure the final digest matches the quote
-4. During that replay, locate the TLS key binding event (contains the certificate pubkey hash) to prove the attested workload owns the negotiated TLS key
-5. Verify bootchain (MRTD, RTMR0-2), app compose hash, and OS image hash against policy
+3. Reject unsupported IMR indexes, recompute each RTMR3 runtime event digest from its type/name/payload, then replay the authenticated digests in order and ensure the final RTMR3 matches the quote
+4. Locate the RTMR3 dstack runtime TLS key binding event (contains the certificate pubkey hash) to prove the attested workload owns the negotiated TLS key
+5. Verify bootchain (MRTD, RTMR0-2), app compose hash, OS image hash, and optional `expected_rtmr3` against policy. App compose, OS image, and TLS certificate decisions consume only authenticated RTMR3 dstack runtime events.
 
 ## TCB Status Values
 

--- a/core/src/connect.rs
+++ b/core/src/connect.rs
@@ -9,9 +9,84 @@ use crate::error::AtlsVerificationError;
 use crate::policy::Policy;
 use crate::verifier::{AsyncByteStream, Report};
 use crate::AtlsVerifier;
-use rustls::pki_types::ServerName;
-use rustls::{ClientConfig, RootCertStore};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{
+    ClientConfig, DigitallySignedStruct, Error as RustlsError, RootCertStore, SignatureScheme,
+};
 use std::sync::Arc;
+
+/// Certificate verifier for aTLS connections to TEEs.
+///
+/// TEEs serve self-signed certificates, so CA-chain validation would always
+/// fail. Trust in aTLS does not come from the CA hierarchy but from attestation:
+/// the DCAP quote binds the TLS leaf certificate via the event log, and the EKM
+/// session binding prevents replay. This verifier therefore skips **CA chain
+/// validation, hostname/SAN matching, and certificate validity-period checks**,
+/// but still verifies the TLS handshake signature so the peer must prove it holds
+/// the private key for the presented certificate. Per-instance binding (that this
+/// is the *intended* TEE, not merely *a* TEE of the right image) comes from
+/// `expected_rtmr3` in the policy, not from this layer.
+#[derive(Debug)]
+struct AtlsServerCertVerifier {
+    supported_algs: rustls::crypto::WebPkiSupportedAlgorithms,
+}
+
+impl AtlsServerCertVerifier {
+    fn new() -> Self {
+        // Read the algorithms from the process-default CryptoProvider — the same
+        // provider `ClientConfig::builder()` uses — so the verifier never enforces
+        // a different (e.g. hardcoded) set than the connection negotiates. Fall
+        // back to the platform default only when no provider is installed (in which
+        // case `ClientConfig::builder()` would itself panic first).
+        #[cfg(not(target_arch = "wasm32"))]
+        let fallback = rustls::crypto::aws_lc_rs::default_provider();
+        #[cfg(target_arch = "wasm32")]
+        let fallback = rustls::crypto::ring::default_provider();
+        let supported_algs = rustls::crypto::CryptoProvider::get_default()
+            .map(|p| p.signature_verification_algorithms)
+            .unwrap_or(fallback.signature_verification_algorithms);
+        Self { supported_algs }
+    }
+}
+
+impl ServerCertVerifier for AtlsServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        // Skip CA chain, hostname, and expiry — trust comes from attestation.
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        // Still required — the peer must prove it holds the certificate's private key.
+        rustls::crypto::verify_tls12_signature(message, cert, dss, &self.supported_algs)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        // Still required — the peer must prove it holds the certificate's private key.
+        rustls::crypto::verify_tls13_signature(message, cert, dss, &self.supported_algs)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.supported_algs.supported_schemes()
+    }
+}
 
 // Platform-specific TLS types
 #[cfg(not(target_arch = "wasm32"))]
@@ -26,15 +101,18 @@ use futures_rustls::TlsConnector;
 
 /// Perform TLS handshake and return stream with peer certificate and session EKM.
 ///
-/// This establishes a TLS connection using CA-verified certificates from
-/// the webpki-roots bundle and captures the server's leaf certificate and
-/// TLS session Exported Keying Material (EKM) for session binding.
+/// Captures the server's leaf certificate and the TLS session Exported Keying
+/// Material (EKM) for attestation binding.
 ///
 /// # Arguments
 ///
 /// * `stream` - The underlying transport stream (e.g., TcpStream)
 /// * `server_name` - The server hostname for TLS SNI
 /// * `alpn` - Optional ALPN protocols (e.g., `["http/1.1", "h2"]`)
+/// * `accept_self_signed_certs` - When `true`, skip CA chain, hostname/SAN, and
+///   certificate-expiry validation (for TEE self-signed certs); the handshake
+///   signature is still verified. When `false`, standard webpki-roots CA and
+///   hostname validation applies.
 ///
 /// # Returns
 ///
@@ -43,18 +121,29 @@ pub async fn tls_handshake<S>(
     stream: S,
     server_name: &str,
     alpn: Option<Vec<String>>,
+    accept_self_signed_certs: bool,
 ) -> Result<(TlsStream<S>, Vec<u8>, Vec<u8>), AtlsVerificationError>
 where
     S: AsyncByteStream + 'static,
 {
-    debug!("Starting TLS handshake to {}", server_name);
+    debug!(
+        "Starting TLS handshake to {} (accept_self_signed_certs={})",
+        server_name, accept_self_signed_certs
+    );
 
-    let mut root_store = RootCertStore::empty();
-    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let mut config = if accept_self_signed_certs {
+        ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(AtlsServerCertVerifier::new()))
+            .with_no_client_auth()
+    } else {
+        let mut root_store = RootCertStore::empty();
+        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
-    let mut config = ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
+        ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth()
+    };
 
     if let Some(protocols) = alpn {
         config.alpn_protocols = protocols.into_iter().map(|s| s.into_bytes()).collect();
@@ -97,7 +186,7 @@ where
 /// Establish a TLS connection with attestation verification.
 ///
 /// This function combines TLS handshake with attestation verification:
-/// 1. Performs a TLS handshake with CA certificate verification
+/// 1. Performs a TLS handshake (optionally accepting self-signed TEE certs)
 /// 2. Captures the server's leaf certificate
 /// 3. Creates the appropriate verifier from the policy
 /// 4. Performs attestation verification over the TLS stream
@@ -143,7 +232,9 @@ where
     // Initialize logging (idempotent, only runs once)
     crate::logging::init();
 
-    let (mut tls_stream, peer_cert, session_ekm) = tls_handshake(stream, server_name, alpn).await?;
+    let accept_self_signed = policy.accept_self_signed_certs();
+    let (mut tls_stream, peer_cert, session_ekm) =
+        tls_handshake(stream, server_name, alpn, accept_self_signed).await?;
 
     debug!("Starting attestation verification");
     let verifier = policy.into_verifier()?;

--- a/core/src/connect.rs
+++ b/core/src/connect.rs
@@ -111,8 +111,9 @@ use futures_rustls::TlsConnector;
 /// * `alpn` - Optional ALPN protocols (e.g., `["http/1.1", "h2"]`)
 /// * `accept_self_signed_certs` - When `true`, skip CA chain, hostname/SAN, and
 ///   certificate-expiry validation (for TEE self-signed certs); the handshake
-///   signature is still verified. When `false`, standard webpki-roots CA and
-///   hostname validation applies.
+///   signature is still verified. Low-level callers that enable this must provide
+///   an equivalent endpoint binding, such as a verified RTMR3 pin. When `false`,
+///   standard webpki-roots CA and hostname validation applies.
 ///
 /// # Returns
 ///
@@ -186,9 +187,10 @@ where
 /// Establish a TLS connection with attestation verification.
 ///
 /// This function combines TLS handshake with attestation verification:
-/// 1. Performs a TLS handshake (optionally accepting self-signed TEE certs)
-/// 2. Captures the server's leaf certificate
-/// 3. Creates the appropriate verifier from the policy
+/// 1. Validates the policy and creates the appropriate verifier
+/// 2. Performs a TLS handshake (optionally accepting self-signed TEE certs;
+///    high-level policy validation requires RTMR3 instance pinning in that mode)
+/// 3. Captures the server's leaf certificate and session EKM
 /// 4. Performs attestation verification over the TLS stream
 /// 5. Returns the verified TLS stream and attestation report
 ///
@@ -233,11 +235,11 @@ where
     crate::logging::init();
 
     let accept_self_signed = policy.accept_self_signed_certs();
+    let verifier = policy.into_verifier()?;
     let (mut tls_stream, peer_cert, session_ekm) =
         tls_handshake(stream, server_name, alpn, accept_self_signed).await?;
 
     debug!("Starting attestation verification");
-    let verifier = policy.into_verifier()?;
     let report = verifier
         .verify(&mut tls_stream, &peer_cert, &session_ekm, server_name)
         .await?;

--- a/core/src/dstack/config.rs
+++ b/core/src/dstack/config.rs
@@ -41,6 +41,13 @@ pub struct DstackTDXVerifierConfig {
     /// The SHA256 hash of the OS image that should be running in the TD.
     pub os_image_hash: Option<String>,
 
+    /// Expected RTMR3 (96 lowercase hex chars).
+    ///
+    /// If provided, the verifier will check that the attestation's RTMR3 -
+    /// the full runtime measurement register - matches this expected value.
+    /// If None, RTMR3 is not pinned.
+    pub expected_rtmr3: Option<String>,
+
     /// PCCS URL for collateral fetching.
     ///
     /// If None, uses Intel's default PCS endpoint.
@@ -62,6 +69,7 @@ impl Default for DstackTDXVerifierConfig {
             disable_runtime_verification: false,
             expected_bootchain: None,
             os_image_hash: None,
+            expected_rtmr3: None,
             pccs_url: None,
             cache_collateral: true,
         }
@@ -127,6 +135,12 @@ impl DstackTDXVerifierBuilder {
     /// Set the expected OS image hash.
     pub fn os_image_hash(mut self, hash: impl Into<String>) -> Self {
         self.config.os_image_hash = Some(hash.into());
+        self
+    }
+
+    /// Set the expected RTMR3 (96 lowercase hex chars).
+    pub fn expected_rtmr3(mut self, rtmr3: impl Into<String>) -> Self {
+        self.config.expected_rtmr3 = Some(rtmr3.into());
         self
     }
 

--- a/core/src/dstack/default_app_compose.rs
+++ b/core/src/dstack/default_app_compose.rs
@@ -354,7 +354,10 @@ mod tests {
         let full = merge_with_default_app_compose(&user_compose);
 
         // User values are preserved
-        assert_eq!(full["docker_compose_file"], "services:\n  app:\n    image: test");
+        assert_eq!(
+            full["docker_compose_file"],
+            "services:\n  app:\n    image: test"
+        );
         assert_eq!(full["allowed_envs"], json!(["MY_SECRET"]));
 
         // Defaults are filled in

--- a/core/src/dstack/policy.rs
+++ b/core/src/dstack/policy.rs
@@ -84,9 +84,10 @@ pub struct DstackTdxPolicy {
     /// verified, so the peer must hold the certificate's private key regardless.
     ///
     /// Because this drops the hostname check, it removes the only per-connection
-    /// endpoint binding at the TLS layer; pair it with `expected_rtmr3` to bind the
-    /// specific instance. It is rejected together with `disable_runtime_verification`
-    /// (that combination pins neither identity nor measurements).
+    /// endpoint binding at the TLS layer; `expected_rtmr3` is required to bind the
+    /// specific instance. It is also rejected together with
+    /// `disable_runtime_verification` (that combination pins neither identity nor
+    /// measurements).
     #[serde(default)]
     pub accept_self_signed_certs: bool,
 }
@@ -110,7 +111,9 @@ impl Default for DstackTdxPolicy {
 
 /// Check if a string is a valid lowercase hex string.
 fn is_valid_hex(s: &str) -> bool {
-    !s.is_empty() && s.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
 }
 
 impl DstackTdxPolicy {
@@ -138,6 +141,7 @@ impl DstackTdxPolicy {
     /// - `expected_bootchain` fields are valid hex strings (if provided)
     /// - `grace_period` requires `allowed_tcb_status` to include `OutOfDate`
     /// - `accept_self_signed_certs` is not combined with `disable_runtime_verification`
+    /// - `accept_self_signed_certs` is bound to a specific instance by `expected_rtmr3`
     pub fn validate(&self) -> Result<(), AtlsVerificationError> {
         // Validate TCB status values
         for status in &self.allowed_tcb_status {
@@ -158,15 +162,18 @@ impl DstackTdxPolicy {
                     .into(),
             ));
         }
+        if self.accept_self_signed_certs && self.expected_rtmr3.is_none() {
+            return Err(AtlsVerificationError::Configuration(
+                "accept_self_signed_certs requires expected_rtmr3".into(),
+            ));
+        }
 
         // Validate grace period policy requirements
-        if self.grace_period.is_some() {
-            if !self.allowed_tcb_status.iter().any(|s| s == "OutOfDate") {
-                return Err(AtlsVerificationError::Configuration(
-                    "grace_period requires allowed_tcb_status to include OutOfDate"
-                        .into(),
-                ));
-            }
+        if self.grace_period.is_some() && !self.allowed_tcb_status.iter().any(|s| s == "OutOfDate")
+        {
+            return Err(AtlsVerificationError::Configuration(
+                "grace_period requires allowed_tcb_status to include OutOfDate".into(),
+            ));
         }
 
         // Validate os_image_hash is hex
@@ -279,7 +286,9 @@ mod tests {
     #[test]
     fn test_dstack_tdx_policy_dev() {
         let policy = DstackTdxPolicy::dev();
-        assert!(policy.allowed_tcb_status.contains(&"SWHardeningNeeded".to_string()));
+        assert!(policy
+            .allowed_tcb_status
+            .contains(&"SWHardeningNeeded".to_string()));
         assert!(policy.disable_runtime_verification);
         // dev() must not also skip cert validation — that combination is rejected.
         assert!(!policy.accept_self_signed_certs);
@@ -292,6 +301,7 @@ mod tests {
         let policy = DstackTdxPolicy {
             accept_self_signed_certs: true,
             disable_runtime_verification: true,
+            expected_rtmr3: Some(TEST_RTMR3.into()),
             ..Default::default()
         };
         let err = policy
@@ -304,6 +314,35 @@ mod tests {
             ),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn test_self_signed_without_rtmr3_rejected() {
+        let policy = DstackTdxPolicy {
+            accept_self_signed_certs: true,
+            ..Default::default()
+        };
+
+        let err = policy
+            .validate()
+            .expect_err("self-signed certificate acceptance must require an RTMR3 pin")
+            .to_string();
+
+        assert!(
+            err.contains("accept_self_signed_certs requires expected_rtmr3"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_self_signed_with_rtmr3_accepted() {
+        let policy = DstackTdxPolicy {
+            expected_rtmr3: Some(TEST_RTMR3.into()),
+            accept_self_signed_certs: true,
+            ..Default::default()
+        };
+
+        assert!(policy.validate().is_ok());
     }
 
     #[test]

--- a/core/src/dstack/policy.rs
+++ b/core/src/dstack/policy.rs
@@ -32,6 +32,20 @@ pub struct DstackTdxPolicy {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub os_image_hash: Option<String>,
 
+    /// Expected RTMR3 - full runtime measurement register (96 lowercase hex
+    /// chars, i.e. a SHA384 digest).
+    ///
+    /// RTMR3 accumulates the application runtime events (compose hash, OS image
+    /// hash, TLS certificate, ...). Pinning it constrains the whole runtime
+    /// event sequence, not just the individual events checked by
+    /// `app_compose` / `os_image_hash`.
+    ///
+    /// When absent (the default), no RTMR3 check is performed, so existing
+    /// policies keep their current behavior. Like the other runtime checks, it
+    /// is skipped when `disable_runtime_verification` is true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_rtmr3: Option<String>,
+
     /// Allowed TCB status values.
     #[serde(default = "default_allowed_tcb_status")]
     pub allowed_tcb_status: Vec<String>,
@@ -59,6 +73,22 @@ pub struct DstackTdxPolicy {
     /// Set to true only for development/testing.
     #[serde(default)]
     pub disable_runtime_verification: bool,
+
+    /// Accept the server's TLS certificate without CA-chain, hostname/SAN, or
+    /// expiry validation (for TEE self-signed certs).
+    ///
+    /// **Defaults to `false`** — standard webpki-roots CA + hostname validation
+    /// applies. Set to `true` only for TEEs that serve self-signed certificates,
+    /// where trust comes from attestation (the DCAP quote binds the leaf cert via
+    /// the event log, plus EKM session binding). The handshake signature is always
+    /// verified, so the peer must hold the certificate's private key regardless.
+    ///
+    /// Because this drops the hostname check, it removes the only per-connection
+    /// endpoint binding at the TLS layer; pair it with `expected_rtmr3` to bind the
+    /// specific instance. It is rejected together with `disable_runtime_verification`
+    /// (that combination pins neither identity nor measurements).
+    #[serde(default)]
+    pub accept_self_signed_certs: bool,
 }
 
 impl Default for DstackTdxPolicy {
@@ -67,11 +97,13 @@ impl Default for DstackTdxPolicy {
             expected_bootchain: None,
             app_compose: None,
             os_image_hash: None,
+            expected_rtmr3: None,
             allowed_tcb_status: default_allowed_tcb_status(),
             grace_period: None,
             pccs_url: default_pccs_url(),
             cache_collateral: false,
             disable_runtime_verification: false,
+            accept_self_signed_certs: false,
         }
     }
 }
@@ -105,6 +137,7 @@ impl DstackTdxPolicy {
     /// - `os_image_hash` is a valid hex string (if provided)
     /// - `expected_bootchain` fields are valid hex strings (if provided)
     /// - `grace_period` requires `allowed_tcb_status` to include `OutOfDate`
+    /// - `accept_self_signed_certs` is not combined with `disable_runtime_verification`
     pub fn validate(&self) -> Result<(), AtlsVerificationError> {
         // Validate TCB status values
         for status in &self.allowed_tcb_status {
@@ -114,6 +147,16 @@ impl DstackTdxPolicy {
                     status, TCB_STATUS_LIST
                 )));
             }
+        }
+
+        // Skipping certificate validation AND runtime verification together leaves
+        // no CA trust, no hostname binding, and no measurement pinning — the peer is
+        // authenticated as nothing more than "some TDX machine". Reject the combination.
+        if self.accept_self_signed_certs && self.disable_runtime_verification {
+            return Err(AtlsVerificationError::Configuration(
+                "accept_self_signed_certs cannot be combined with disable_runtime_verification"
+                    .into(),
+            ));
         }
 
         // Validate grace period policy requirements
@@ -159,6 +202,15 @@ impl DstackTdxPolicy {
             }
         }
 
+        // Validate expected_rtmr3 is a full SHA384 measurement (48 bytes = 96 hex chars)
+        if let Some(ref rtmr3) = self.expected_rtmr3 {
+            if !is_valid_hex(rtmr3) || rtmr3.len() != 96 {
+                return Err(AtlsVerificationError::Configuration(
+                    "expected_rtmr3 must be a 96-character lowercase hex string".into(),
+                ));
+            }
+        }
+
         Ok(())
     }
 }
@@ -187,6 +239,9 @@ impl IntoVerifier for DstackTdxPolicy {
         if let Some(os_hash) = self.os_image_hash {
             builder = builder.os_image_hash(os_hash);
         }
+        if let Some(rtmr3) = self.expected_rtmr3 {
+            builder = builder.expected_rtmr3(rtmr3);
+        }
 
         builder = builder.allowed_tcb_status(self.allowed_tcb_status);
         if let Some(grace) = self.grace_period {
@@ -207,12 +262,18 @@ impl IntoVerifier for DstackTdxPolicy {
 mod tests {
     use super::*;
 
+    /// A well-formed RTMR3 pin (48 bytes = 96 hex chars).
+    const TEST_RTMR3: &str = "1f2e3d4c5b6a79880716253443526170a1b2c3d4e5f60718293a4b5c6d7e8f900a1b2c3d4e5f60718293a4b5c6d7e8f9";
+
     #[test]
     fn test_dstack_tdx_policy_default() {
         let policy = DstackTdxPolicy::default();
         assert_eq!(policy.allowed_tcb_status, vec!["UpToDate"]);
         assert!(policy.expected_bootchain.is_none());
+        assert!(policy.expected_rtmr3.is_none());
         assert!(!policy.disable_runtime_verification);
+        // Safe default: CA + hostname validation applies unless explicitly opted out.
+        assert!(!policy.accept_self_signed_certs);
     }
 
     #[test]
@@ -220,6 +281,82 @@ mod tests {
         let policy = DstackTdxPolicy::dev();
         assert!(policy.allowed_tcb_status.contains(&"SWHardeningNeeded".to_string()));
         assert!(policy.disable_runtime_verification);
+        // dev() must not also skip cert validation — that combination is rejected.
+        assert!(!policy.accept_self_signed_certs);
+        assert!(policy.validate().is_ok());
+    }
+
+    #[test]
+    fn test_self_signed_with_disable_runtime_rejected() {
+        // Skipping cert validation AND runtime verification pins nothing — rejected.
+        let policy = DstackTdxPolicy {
+            accept_self_signed_certs: true,
+            disable_runtime_verification: true,
+            ..Default::default()
+        };
+        let err = policy
+            .validate()
+            .expect_err("self-signed + disable_runtime must be rejected")
+            .to_string();
+        assert!(
+            err.contains(
+                "accept_self_signed_certs cannot be combined with disable_runtime_verification"
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_valid_rtmr3_accepted() {
+        let policy = DstackTdxPolicy {
+            expected_rtmr3: Some(TEST_RTMR3.into()),
+            disable_runtime_verification: true,
+            ..Default::default()
+        };
+        assert!(policy.validate().is_ok());
+    }
+
+    #[test]
+    fn test_invalid_rtmr3_rejected() {
+        // A malformed pin must be caught at load time, not silently at compare time.
+        for bad in [
+            "not-valid-hex!",
+            &TEST_RTMR3.to_uppercase(),
+            &TEST_RTMR3[..94], // 94 hex chars: valid hex, wrong length
+            "",
+        ] {
+            let policy = DstackTdxPolicy {
+                expected_rtmr3: Some(bad.into()),
+                disable_runtime_verification: true,
+                ..Default::default()
+            };
+            let err = policy
+                .validate()
+                .expect_err("malformed expected_rtmr3 must be rejected")
+                .to_string();
+            assert!(
+                err.contains("expected_rtmr3 must be a 96-character lowercase hex string"),
+                "unexpected error for {:?}: {}",
+                bad,
+                err
+            );
+        }
+    }
+
+    #[test]
+    fn test_rtmr3_json_optional() {
+        // Policies written before RTMR3 pinning existed must keep parsing, and
+        // must not gain the key when serialized back out.
+        let without: DstackTdxPolicy =
+            serde_json::from_str(r#"{"allowed_tcb_status": ["UpToDate"]}"#).unwrap();
+        assert!(without.expected_rtmr3.is_none());
+        assert!(!serde_json::to_string(&without)
+            .unwrap()
+            .contains("expected_rtmr3"));
+
+        let with: DstackTdxPolicy =
+            serde_json::from_str(&format!(r#"{{"expected_rtmr3": "{}"}}"#, TEST_RTMR3)).unwrap();
+        assert_eq!(with.expected_rtmr3.as_deref(), Some(TEST_RTMR3));
     }
 
     #[test]

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -9,7 +9,7 @@ use dcap_qvl::verify::{verify, VerifiedReport};
 use dcap_qvl::QuoteCollateralV3;
 use dstack_sdk_types::dstack::{EventLog, GetQuoteResponse};
 use log::{debug, warn};
-use sha2::{Digest, Sha256, Sha512};
+use sha2::{Digest, Sha256, Sha384, Sha512};
 
 use crate::dstack::compose_hash::get_compose_hash;
 use crate::dstack::config::DstackTDXVerifierConfig;
@@ -531,6 +531,14 @@ impl AtlsVerifier for DstackTDXVerifier {
             .map_err(|e| AtlsVerificationError::Other(e.into()))?;
         debug!("Event log parsed, {} events found", events.len());
 
+        // 2b. Authenticate the RTMR3 event payloads against their logged digests.
+        // replay_rtmrs() (step 6) trusts each event's `digest` verbatim and never
+        // rebinds it to (event_type, event, event_payload); without this, an attacker
+        // can keep the genuine digests (so RTMR replay still matches the quote) while
+        // rewriting event_payload to forge the cert / compose-hash / os-image-hash that
+        // the checks below read. This binds payload -> digest; replay binds digest -> quote.
+        verify_event_log_integrity(&events)?;
+
         // 3. Verify certificate in event log
         debug!("Verifying certificate in event log");
         let cert_in_eventlog = self.verify_cert_in_eventlog(peer_cert, &events)?;
@@ -682,4 +690,123 @@ fn parse_content_length(headers: &[u8]) -> Option<usize> {
         }
     }
     None
+}
+
+/// Authenticate RTMR3 event payloads against their logged digests.
+///
+/// dstack extends RTMR3 with `digest = sha384(event_type.to_le_bytes() || b":" ||
+/// event || b":" || event_payload)`, but `replay_rtmrs()` replays the `digest` field
+/// verbatim and never rebinds it to the event contents. atlas reads `event_payload`
+/// (cert hash, compose-hash, os-image-hash) to make trust decisions, so a payload that
+/// is not tied back to its digest is attacker-controlled. Recomputing the digest closes
+/// the chain: payload -> digest here, digest -> quote via `verify_rtmr_replay`.
+///
+/// Only IMR 3 is checked, mirroring dstack `cc-eventlog` `TdxEventLog::validate`: IMR 0-2
+/// use the TCG multi-digest format (not this scheme) and are verified against the DCAP
+/// report by `verify_bootchain`, never via `event_payload`.
+fn verify_event_log_integrity(events: &[EventLog]) -> Result<(), AtlsVerificationError> {
+    for event in events {
+        if event.imr != 3 {
+            continue;
+        }
+        let payload = hex::decode(&event.event_payload).map_err(|e| {
+            AtlsVerificationError::EventLogParse(format!(
+                "failed to hex-decode event_payload for '{}': {}",
+                event.event, e
+            ))
+        })?;
+
+        let mut hasher = Sha384::new();
+        hasher.update(event.event_type.to_le_bytes());
+        hasher.update(b":");
+        hasher.update(event.event.as_bytes());
+        hasher.update(b":");
+        hasher.update(&payload);
+
+        if hex::encode(hasher.finalize()) != event.digest {
+            return Err(AtlsVerificationError::EventLogDigestMismatch {
+                event: event.event.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(imr: u32, event_type: u32, event: &str, event_payload: &str, digest: &str) -> EventLog {
+        EventLog {
+            imr,
+            event_type,
+            digest: digest.to_string(),
+            event: event.to_string(),
+            event_payload: event_payload.to_string(),
+        }
+    }
+
+    /// Real RTMR3 events from a dstack event log (sdk/simulator/eventlog.json), including
+    /// an empty-payload event. Proves our recomputation reproduces dstack's actual
+    /// `event_digest` output — a non-circular check of the derivation, not just self-consistency.
+    #[test]
+    fn test_event_log_integrity_genuine_dstack_digests_success() {
+        let events = vec![
+            ev(
+                3,
+                0x0800_0001,
+                "app-id",
+                "ea549f02e1a25fabd1cb788380e033ec5461b2ff",
+                "b01c7a2e6a406ae9cd5aa81451e4614e112b8f404df12e6ef506962c1a5279a94dc58da0923c4b7db89e26da9e538302",
+            ),
+            ev(
+                3,
+                0x0800_0001,
+                "compose-hash",
+                "ea549f02e1a25fabd1cb788380e033ec5461b2ffe4328d753642cf035452e48b",
+                "9c1fecc259af1e8494484a391bdef460cb74d677c76dd114b1e9e7fac343da4e773b2b0eb8df7a6fc0dd8ba5edbb30e1",
+            ),
+            ev(
+                3,
+                0x0800_0001,
+                "system-ready",
+                "",
+                "1a76b2a80a0be71eae59f80945d876351a7a3fb8e9fd1ff1cede5734aa84ea11fd72b4edfbb6f04e5a85edd114c751bd",
+            ),
+        ];
+        assert!(verify_event_log_integrity(&events).is_ok());
+    }
+
+    /// Finding A: keep the genuine digest (so RTMR replay still matches the quote) but
+    /// rewrite the payload. Must be rejected — otherwise cert/compose/os-image are forgeable
+    /// by anyone serving the event log.
+    #[test]
+    fn test_event_log_integrity_forged_payload_failure() {
+        let events = vec![ev(
+            3,
+            0x0800_0001,
+            "compose-hash",
+            // attacker-substituted payload, genuine compose-hash digest below
+            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "9c1fecc259af1e8494484a391bdef460cb74d677c76dd114b1e9e7fac343da4e773b2b0eb8df7a6fc0dd8ba5edbb30e1",
+        )];
+        assert!(matches!(
+            verify_event_log_integrity(&events),
+            Err(AtlsVerificationError::EventLogDigestMismatch { .. })
+        ));
+    }
+
+    /// IMR 0-2 use the TCG multi-digest format, not `event_digest`; dstack `validate()`
+    /// skips them and so must we — their payloads are never trusted by atlas.
+    #[test]
+    fn test_event_log_integrity_ignores_non_rtmr3_success() {
+        let events = vec![ev(
+            0,
+            0x8000_000b,
+            "",
+            "095464785461626c6500",
+            "0e35f1b315ba6c912cf791e5c79dd9d3a2b8704516aa27d4e5aa78fb09ede04aef2bbd02ac7a8734c48562b9c26ba35d",
+        )];
+        assert!(verify_event_log_integrity(&events).is_ok());
+    }
 }

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -862,8 +862,7 @@ mod tests {
             server.shutdown().await.unwrap();
         });
 
-        let mut nonce = [0u8; 32];
-        rand::Rng::fill(&mut rand::thread_rng(), &mut nonce);
+        let nonce: [u8; 32] = rand::random();
         let result = get_quote_over_http(&mut client, &nonce, "example.test").await;
         writer.await.unwrap();
         result

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -32,10 +32,17 @@ struct CachedCollateral {
 /// Default collateral cache TTL: 8 hours (in seconds).
 const COLLATERAL_CACHE_TTL_SECS: u64 = 8 * 3600;
 
+/// dstack runtime events are extended into RTMR3 with this event type.
+const DSTACK_RUNTIME_EVENT_TYPE: u32 = 0x0800_0001;
+
 /// Response from the /tdx_quote endpoint.
 #[derive(Debug, serde::Deserialize)]
 struct QuoteEndpointResponse {
     quote: GetQuoteResponse,
+}
+
+fn is_dstack_runtime_event(event: &EventLog, name: &str) -> bool {
+    event.imr == 3 && event.event_type == DSTACK_RUNTIME_EVENT_TYPE && event.event == name
 }
 
 /// DstackTDXVerifier performs TDX attestation verification for dstack deployments.
@@ -93,11 +100,10 @@ impl DstackTDXVerifier {
         // Parse quote to get cache key components (FMSPC and CA)
         let parsed_quote = Quote::parse(quote)
             .map_err(|e| AtlsVerificationError::Quote(format!("Failed to parse quote: {}", e)))?;
-        let fmspc = hex::encode_upper(
-            parsed_quote
-                .fmspc()
-                .map_err(|e| AtlsVerificationError::Quote(format!("Failed to get FMSPC: {}", e)))?,
-        );
+        let fmspc =
+            hex::encode_upper(parsed_quote.fmspc().map_err(|e| {
+                AtlsVerificationError::Quote(format!("Failed to get FMSPC: {}", e))
+            })?);
         let ca = parsed_quote
             .ca()
             .map_err(|e| AtlsVerificationError::Quote(format!("Failed to get CA: {}", e)))?;
@@ -146,21 +152,22 @@ impl DstackTDXVerifier {
             }
             None => {
                 debug!("Fetching collateral from {}", pccs_url);
-                let c = get_collateral(pccs_url, quote)
-                    .await
-                    .map_err(|e| {
-                        AtlsVerificationError::Quote(format!("Failed to get collateral: {}", e))
-                    })?;
+                let c = get_collateral(pccs_url, quote).await.map_err(|e| {
+                    AtlsVerificationError::Quote(format!("Failed to get collateral: {}", e))
+                })?;
 
                 // Cache if enabled
                 if self.config.cache_collateral {
                     match self.cached_collateral.write() {
                         Ok(mut guard) => {
                             debug!("Caching collateral for FMSPC={}, CA={}", fmspc, ca);
-                            guard.insert(cache_key, CachedCollateral {
-                                collateral: c.clone(),
-                                cached_at_secs: now_secs,
-                            });
+                            guard.insert(
+                                cache_key,
+                                CachedCollateral {
+                                    collateral: c.clone(),
+                                    cached_at_secs: now_secs,
+                                },
+                            );
                         }
                         Err(_) => {
                             warn!("Collateral cache lock poisoned, skipping cache write");
@@ -174,8 +181,9 @@ impl DstackTDXVerifier {
         debug!("Collateral received, verifying DCAP quote");
 
         // Verify the quote
-        let report = verify(quote, &collateral, now_secs)
-            .map_err(|e| AtlsVerificationError::Quote(format!("DCAP verification failed: {}", e)))?;
+        let report = verify(quote, &collateral, now_secs).map_err(|e| {
+            AtlsVerificationError::Quote(format!("DCAP verification failed: {}", e))
+        })?;
 
         debug!("DCAP verification complete, TCB status: {}", report.status);
 
@@ -186,10 +194,7 @@ impl DstackTDXVerifier {
             .iter()
             .any(|s| s == &report.status);
 
-        debug!(
-            "TCB status '{}' allowed: {}",
-            report.status, tcb_allowed
-        );
+        debug!("TCB status '{}' allowed: {}", report.status, tcb_allowed);
 
         // If TCB status is OutOfDate, check it's within the grace period (if configured)
         // TODO: enforce_grace_period is currently implemented in a complex manner since
@@ -197,7 +202,13 @@ impl DstackTDXVerifier {
         // extract the TCB date from the quote and collateral manually, which is not ideal.
         // We should update enforce_grace_period when dcap-qvl adds TCB info to the VerifiedReport.
         // This would remove almost all the tdx/grace_period.rs code.
-        enforce_grace_period(&report, &parsed_quote, &collateral, self.config.grace_period, now_secs)?;
+        enforce_grace_period(
+            &report,
+            &parsed_quote,
+            &collateral,
+            self.config.grace_period,
+            now_secs,
+        )?;
 
         if !tcb_allowed {
             return Err(AtlsVerificationError::TcbStatusNotAllowed {
@@ -327,7 +338,7 @@ impl DstackTDXVerifier {
         // Find last "New TLS Certificate" event
         let cert_event = events
             .iter()
-            .rfind(|e| e.event == "New TLS Certificate");
+            .rfind(|e| is_dstack_runtime_event(e, "New TLS Certificate"));
 
         match cert_event {
             Some(event) => {
@@ -381,12 +392,10 @@ impl DstackTDXVerifier {
         // Verify against event log (trusted after RTMR replay verification)
         let event = events
             .iter()
-            .find(|e| e.event == "compose-hash")
-            .ok_or_else(|| {
-                AtlsVerificationError::AppComposeHashMismatch {
-                    expected: expected.clone(),
-                    actual: "<not found in event log>".to_string(),
-                }
+            .find(|e| is_dstack_runtime_event(e, "compose-hash"))
+            .ok_or_else(|| AtlsVerificationError::AppComposeHashMismatch {
+                expected: expected.clone(),
+                actual: "<not found in event log>".to_string(),
             })?;
 
         debug!("App compose hash from event log: {}", event.event_payload);
@@ -421,7 +430,7 @@ impl DstackTDXVerifier {
         // Verify against event log (trusted after RTMR replay verification)
         let event = events
             .iter()
-            .find(|e| e.event == "os-image-hash")
+            .find(|e| is_dstack_runtime_event(e, "os-image-hash"))
             .ok_or_else(|| AtlsVerificationError::OsImageHashMismatch {
                 expected: expected.clone(),
                 actual: Some("<not found in event log>".to_string()),
@@ -532,7 +541,6 @@ impl DstackTDXVerifier {
         debug!("Report data expected: {}", expected);
         debug!("Report data actual:   {}", actual);
 
-        
         if expected != actual {
             return Err(AtlsVerificationError::ReportDataMismatch { expected, actual });
         }
@@ -586,9 +594,9 @@ impl AtlsVerifier for DstackTDXVerifier {
 
         // 4. Verify DCAP quote using dcap-qvl directly
         debug!("Decoding quote for DCAP verification");
-        let quote_bytes = quote_response
-            .decode_quote()
-            .map_err(|e| AtlsVerificationError::Other(anyhow::anyhow!("Failed to decode quote: {}", e)))?;
+        let quote_bytes = quote_response.decode_quote().map_err(|e| {
+            AtlsVerificationError::Other(anyhow::anyhow!("Failed to decode quote: {}", e))
+        })?;
         debug!("Quote decoded ({} bytes)", quote_bytes.len());
 
         // Async quote verification - no blocking!
@@ -596,9 +604,7 @@ impl AtlsVerifier for DstackTDXVerifier {
 
         // 5. Verify report data
         let session_ekm: &[u8; 32] = session_ekm.try_into().map_err(|_| {
-            AtlsVerificationError::Configuration(
-                "session_ekm must be exactly 32 bytes".into(),
-            )
+            AtlsVerificationError::Configuration("session_ekm must be exactly 32 bytes".into())
         })?;
         self.verify_report_data(&nonce, session_ekm, &verified_report)?;
 
@@ -700,13 +706,9 @@ where
         .ok_or_else(|| AtlsVerificationError::Io("Invalid HTTP response".into()))?;
     let response_body = &response_buf[body_start..];
 
-    let response: QuoteEndpointResponse = serde_json::from_slice(response_body)
-        .map_err(|e| {
-            AtlsVerificationError::Quote(format!(
-                "Failed to parse /tdx_quote response: {}",
-                e
-            ))
-        })?;
+    let response: QuoteEndpointResponse = serde_json::from_slice(response_body).map_err(|e| {
+        AtlsVerificationError::Quote(format!("Failed to parse /tdx_quote response: {}", e))
+    })?;
 
     Ok(response.quote)
 }
@@ -742,13 +744,22 @@ fn parse_content_length(headers: &[u8]) -> Option<usize> {
 /// is not tied back to its digest is attacker-controlled. Recomputing the digest closes
 /// the chain: payload -> digest here, digest -> quote via `verify_rtmr_replay`.
 ///
-/// Only IMR 3 is checked, mirroring dstack `cc-eventlog` `TdxEventLog::validate`: IMR 0-2
-/// use the TCG multi-digest format (not this scheme) and are verified against the DCAP
-/// report by `verify_bootchain`, never via `event_payload`.
+/// IMR 0-2 use the TCG multi-digest format (not this scheme) and are verified
+/// against the DCAP report by `verify_bootchain`, never via `event_payload`.
+/// IMR >3 is rejected because dstack `replay_rtmrs()` only replays IMR 0-3; accepting
+/// higher indexes would let unmeasured entries shadow security-sensitive runtime
+/// events.
 fn verify_event_log_integrity(events: &[EventLog]) -> Result<(), AtlsVerificationError> {
     for event in events {
-        if event.imr != 3 {
-            continue;
+        match event.imr {
+            0..=2 => continue,
+            3 => {}
+            other => {
+                return Err(AtlsVerificationError::EventLogParse(format!(
+                    "unsupported IMR index {} in event log entry '{}'",
+                    other, event.event
+                )));
+            }
         }
         let payload = hex::decode(&event.event_payload).map_err(|e| {
             AtlsVerificationError::EventLogParse(format!(
@@ -795,21 +806,21 @@ mod tests {
         let events = vec![
             ev(
                 3,
-                0x0800_0001,
+                DSTACK_RUNTIME_EVENT_TYPE,
                 "app-id",
                 "ea549f02e1a25fabd1cb788380e033ec5461b2ff",
                 "b01c7a2e6a406ae9cd5aa81451e4614e112b8f404df12e6ef506962c1a5279a94dc58da0923c4b7db89e26da9e538302",
             ),
             ev(
                 3,
-                0x0800_0001,
+                DSTACK_RUNTIME_EVENT_TYPE,
                 "compose-hash",
                 "ea549f02e1a25fabd1cb788380e033ec5461b2ffe4328d753642cf035452e48b",
                 "9c1fecc259af1e8494484a391bdef460cb74d677c76dd114b1e9e7fac343da4e773b2b0eb8df7a6fc0dd8ba5edbb30e1",
             ),
             ev(
                 3,
-                0x0800_0001,
+                DSTACK_RUNTIME_EVENT_TYPE,
                 "system-ready",
                 "",
                 "1a76b2a80a0be71eae59f80945d876351a7a3fb8e9fd1ff1cede5734aa84ea11fd72b4edfbb6f04e5a85edd114c751bd",
@@ -825,7 +836,7 @@ mod tests {
     fn test_event_log_integrity_forged_payload_failure() {
         let events = vec![ev(
             3,
-            0x0800_0001,
+            DSTACK_RUNTIME_EVENT_TYPE,
             "compose-hash",
             // attacker-substituted payload, genuine compose-hash digest below
             "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
@@ -849,6 +860,125 @@ mod tests {
             "0e35f1b315ba6c912cf791e5c79dd9d3a2b8704516aa27d4e5aa78fb09ede04aef2bbd02ac7a8734c48562b9c26ba35d",
         )];
         assert!(verify_event_log_integrity(&events).is_ok());
+    }
+
+    #[test]
+    fn test_event_log_integrity_unknown_imr_failure() {
+        for imr in [4, u32::MAX] {
+            let events = vec![ev(
+                imr,
+                DSTACK_RUNTIME_EVENT_TYPE,
+                "compose-hash",
+                "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                "ignored-by-current-replay",
+            )];
+
+            assert!(matches!(
+                verify_event_log_integrity(&events),
+                Err(AtlsVerificationError::EventLogParse(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn test_security_events_outside_rtmr3_failure() {
+        let app_compose = serde_json::json!({"docker_compose_file": "services: {}"});
+        let expected_compose = get_compose_hash(&app_compose).unwrap();
+        let expected_os_image = "11".repeat(32);
+        let cert = b"unmeasured-certificate";
+        let cert_hash = hex::encode(Sha256::digest(cert));
+        let events = vec![
+            ev(
+                0,
+                DSTACK_RUNTIME_EVENT_TYPE,
+                "compose-hash",
+                &expected_compose,
+                "unused",
+            ),
+            ev(
+                1,
+                DSTACK_RUNTIME_EVENT_TYPE,
+                "os-image-hash",
+                &expected_os_image,
+                "unused",
+            ),
+            ev(
+                2,
+                DSTACK_RUNTIME_EVENT_TYPE,
+                "New TLS Certificate",
+                &hex::encode(cert_hash.as_bytes()),
+                "unused",
+            ),
+            ev(3, 0x0800_0002, "compose-hash", &expected_compose, "unused"),
+            ev(
+                3,
+                0x0800_0002,
+                "os-image-hash",
+                &expected_os_image,
+                "unused",
+            ),
+            ev(
+                3,
+                0x0800_0002,
+                "New TLS Certificate",
+                &hex::encode(cert_hash.as_bytes()),
+                "unused",
+            ),
+        ];
+        let verifier = DstackTDXVerifier::new(DstackTDXVerifierConfig {
+            app_compose: Some(app_compose),
+            os_image_hash: Some(expected_os_image),
+            disable_runtime_verification: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert!(!verifier.verify_cert_in_eventlog(cert, &events).unwrap());
+        assert!(verifier.verify_app_compose(&events).is_err());
+        assert!(verifier.verify_os_image_hash(&events).is_err());
+    }
+
+    #[test]
+    fn test_security_events_in_rtmr3_success() {
+        let app_compose = serde_json::json!({"docker_compose_file": "services: {}"});
+        let expected_compose = get_compose_hash(&app_compose).unwrap();
+        let expected_os_image = "11".repeat(32);
+        let cert = b"measured-certificate";
+        let cert_hash = hex::encode(Sha256::digest(cert));
+        let events = vec![
+            ev(
+                3,
+                DSTACK_RUNTIME_EVENT_TYPE,
+                "compose-hash",
+                &expected_compose,
+                "unused",
+            ),
+            ev(
+                3,
+                DSTACK_RUNTIME_EVENT_TYPE,
+                "os-image-hash",
+                &expected_os_image,
+                "unused",
+            ),
+            ev(
+                3,
+                DSTACK_RUNTIME_EVENT_TYPE,
+                "New TLS Certificate",
+                &hex::encode(cert_hash.as_bytes()),
+                "unused",
+            ),
+        ];
+        let verifier = DstackTDXVerifier::new(DstackTDXVerifierConfig {
+            app_compose: Some(app_compose),
+            os_image_hash: Some(expected_os_image),
+            disable_runtime_verification: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert!(verifier.verify_cert_in_eventlog(cert, &events).unwrap());
+        assert!(verifier.verify_app_compose(&events).is_ok());
+        assert!(verifier.verify_os_image_hash(&events).is_ok());
     }
 
     /// Pinned RTMR3 used by the tests (48 bytes = 96 hex chars, SHA384-sized).

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -274,6 +274,44 @@ impl DstackTDXVerifier {
         Ok(())
     }
 
+    /// Verify RTMR3 against the pinned value using the trusted verified report.
+    ///
+    /// RTMR3 holds the accumulated runtime events, so pinning it constrains the
+    /// whole runtime event sequence rather than the individual events.
+    ///
+    /// No-op if `expected_rtmr3` is not configured.
+    fn verify_rtmr3(&self, verified_report: &VerifiedReport) -> Result<(), AtlsVerificationError> {
+        let Some(expected) = self.config.expected_rtmr3.as_ref() else {
+            debug!("No expected RTMR3 configured, skipping RTMR3 pinning");
+            return Ok(());
+        };
+        let expected = expected.to_lowercase();
+
+        // Get the trusted TD report from DCAP verification
+        let td_report = verified_report.report.as_td10().ok_or_else(|| {
+            AtlsVerificationError::TeeTypeMismatch(
+                "expected TDX report but got SGX enclave report".into(),
+            )
+        })?;
+
+        let actual = hex::encode(td_report.rt_mr3);
+        debug!("RTMR3 expected: {}", expected);
+        debug!("RTMR3 actual:   {}", actual);
+        let rtmr3_match = actual == expected;
+        debug!("RTMR3 match: {}", rtmr3_match);
+
+        if !rtmr3_match {
+            return Err(AtlsVerificationError::BootchainMismatch {
+                field: "rtmr3".into(),
+                expected,
+                actual,
+            });
+        }
+
+        debug!("RTMR3 verification successful");
+        Ok(())
+    }
+
     /// Verify certificate is in event log (using dstack-sdk EventLog type).
     ///
     /// Returns Ok(true) if cert matches, Ok(false) if cert not found,
@@ -576,10 +614,13 @@ impl AtlsVerifier for DstackTDXVerifier {
         // 7. Verify bootchain (MRTD, RTMR0-2) against verified report
         self.verify_bootchain(&verified_report)?;
 
-        // 8. Verify app compose hash against trusted event log
+        // 8. Verify pinned RTMR3 against verified report (if configured)
+        self.verify_rtmr3(&verified_report)?;
+
+        // 9. Verify app compose hash against trusted event log
         self.verify_app_compose(&events)?;
 
-        // 9. Verify OS image hash against trusted event log
+        // 10. Verify OS image hash against trusted event log
         self.verify_os_image_hash(&events)?;
 
         debug!("DStack TDX verification complete");
@@ -808,5 +849,113 @@ mod tests {
             "0e35f1b315ba6c912cf791e5c79dd9d3a2b8704516aa27d4e5aa78fb09ede04aef2bbd02ac7a8734c48562b9c26ba35d",
         )];
         assert!(verify_event_log_integrity(&events).is_ok());
+    }
+
+    /// Pinned RTMR3 used by the tests (48 bytes = 96 hex chars, SHA384-sized).
+    const TEST_RTMR3: &str = "1f2e3d4c5b6a79880716253443526170a1b2c3d4e5f60718293a4b5c6d7e8f900a1b2c3d4e5f60718293a4b5c6d7e8f9";
+    /// A different, equally well-formed RTMR3 the TD did not report.
+    const OTHER_RTMR3: &str = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+
+    fn rtmr3_bytes(hex_str: &str) -> [u8; 48] {
+        hex::decode(hex_str)
+            .expect("test RTMR3 must be hex")
+            .try_into()
+            .expect("test RTMR3 must be 48 bytes")
+    }
+
+    /// Build a synthetic DCAP-verified report carrying the given RTMR3.
+    ///
+    /// `VerifiedReport` has no public constructor, so it is deserialized from
+    /// its own serde representation.
+    fn verified_report_with_rtmr3(rt_mr3: [u8; 48]) -> VerifiedReport {
+        use dcap_qvl::quote::TDReport10;
+        let td_report = TDReport10 {
+            tee_tcb_svn: [0u8; 16],
+            mr_seam: [0u8; 48],
+            mr_signer_seam: [0u8; 48],
+            seam_attributes: [0u8; 8],
+            td_attributes: [0u8; 8],
+            xfam: [0u8; 8],
+            mr_td: [0u8; 48],
+            mr_config_id: [0u8; 48],
+            mr_owner: [0u8; 48],
+            mr_owner_config: [0u8; 48],
+            rt_mr0: [0u8; 48],
+            rt_mr1: [0u8; 48],
+            rt_mr2: [0u8; 48],
+            rt_mr3,
+            report_data: [0u8; 64],
+        };
+        let tcb_status = serde_json::json!({ "status": "UpToDate", "advisory_ids": [] });
+        serde_json::from_value(serde_json::json!({
+            "status": "UpToDate",
+            "advisory_ids": [],
+            "report": { "TD10": td_report },
+            "ppid": "",
+            "qe_status": tcb_status,
+            "platform_status": tcb_status,
+        }))
+        .expect("synthetic VerifiedReport should deserialize")
+    }
+
+    /// Verifier exercising `verify_rtmr3` in isolation; the other runtime
+    /// checks are switched off so the config passes `new()` without them.
+    fn verifier_with_expected_rtmr3(expected: Option<&str>) -> DstackTDXVerifier {
+        DstackTDXVerifier::new(DstackTDXVerifierConfig {
+            expected_rtmr3: expected.map(str::to_string),
+            disable_runtime_verification: true,
+            ..Default::default()
+        })
+        .expect("verifier should build")
+    }
+
+    #[test]
+    fn test_verify_rtmr3_matching_pin_accepted() {
+        let verifier = verifier_with_expected_rtmr3(Some(TEST_RTMR3));
+        let report = verified_report_with_rtmr3(rtmr3_bytes(TEST_RTMR3));
+
+        assert!(verifier.verify_rtmr3(&report).is_ok());
+    }
+
+    #[test]
+    fn test_verify_rtmr3_uppercase_pin_accepted() {
+        // Expected values are normalized before comparison, so a pin supplied
+        // through the builder (which bypasses policy validation) still matches.
+        let verifier = verifier_with_expected_rtmr3(Some(&TEST_RTMR3.to_uppercase()));
+        let report = verified_report_with_rtmr3(rtmr3_bytes(TEST_RTMR3));
+
+        assert!(verifier.verify_rtmr3(&report).is_ok());
+    }
+
+    #[test]
+    fn test_verify_rtmr3_mismatch_rejected() {
+        let verifier = verifier_with_expected_rtmr3(Some(TEST_RTMR3));
+        let report = verified_report_with_rtmr3(rtmr3_bytes(OTHER_RTMR3));
+
+        let err = verifier
+            .verify_rtmr3(&report)
+            .expect_err("mismatched RTMR3 must fail the connection");
+
+        match err {
+            AtlsVerificationError::BootchainMismatch {
+                field,
+                expected,
+                actual,
+            } => {
+                assert_eq!(field, "rtmr3");
+                assert_eq!(expected, TEST_RTMR3);
+                assert_eq!(actual, OTHER_RTMR3);
+            }
+            other => panic!("expected BootchainMismatch, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_verify_rtmr3_absent_pin_skips_check() {
+        // Backward compatibility: policies without expected_rtmr3 accept any RTMR3.
+        let verifier = verifier_with_expected_rtmr3(None);
+        let report = verified_report_with_rtmr3(rtmr3_bytes(OTHER_RTMR3));
+
+        assert!(verifier.verify_rtmr3(&report).is_ok());
     }
 }

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -32,6 +32,12 @@ struct CachedCollateral {
 /// Default collateral cache TTL: 8 hours (in seconds).
 const COLLATERAL_CACHE_TTL_SECS: u64 = 8 * 3600;
 
+/// Maximum size of the unauthenticated `/tdx_quote` HTTP response headers.
+const MAX_QUOTE_RESPONSE_HEADER_SIZE: usize = 64 * 1024;
+
+/// Maximum size of the unauthenticated `/tdx_quote` HTTP response body.
+const MAX_QUOTE_RESPONSE_BODY_SIZE: usize = 16 * 1024 * 1024;
+
 /// dstack runtime events are extended into RTMR3 with this event type.
 const DSTACK_RUNTIME_EVENT_TYPE: u32 = 0x0800_0001;
 
@@ -673,9 +679,11 @@ where
         .await
         .map_err(|e| AtlsVerificationError::Io(e.to_string()))?;
 
-    // Read HTTP response
+    // Read the unauthenticated HTTP response with strict framing and size bounds.
+    // The peer controls these bytes until quote verification completes.
     let mut response_buf = Vec::new();
     let mut chunk = [0u8; 4096];
+    let mut expected_response_len = None;
 
     // Read until we have the complete response
     loop {
@@ -688,14 +696,37 @@ where
         }
         response_buf.extend_from_slice(&chunk[..n]);
 
-        // Check if we have the complete response (look for end of body)
-        if let Some(body_start) = find_http_body_start(&response_buf) {
-            // Try to parse content-length header
-            if let Some(content_length) = parse_content_length(&response_buf[..body_start]) {
-                if response_buf.len() >= body_start + content_length {
-                    break;
+        if expected_response_len.is_none() {
+            if let Some(body_start) = find_http_body_start(&response_buf) {
+                if body_start > MAX_QUOTE_RESPONSE_HEADER_SIZE {
+                    return Err(AtlsVerificationError::Io(format!(
+                        "quote response headers exceed {} bytes",
+                        MAX_QUOTE_RESPONSE_HEADER_SIZE
+                    )));
                 }
+
+                let content_length = parse_content_length(&response_buf[..body_start])?;
+                if content_length > MAX_QUOTE_RESPONSE_BODY_SIZE {
+                    return Err(AtlsVerificationError::Io(format!(
+                        "quote response body exceeds {} bytes",
+                        MAX_QUOTE_RESPONSE_BODY_SIZE
+                    )));
+                }
+
+                expected_response_len =
+                    Some(body_start.checked_add(content_length).ok_or_else(|| {
+                        AtlsVerificationError::Io("quote response length overflow".into())
+                    })?);
+            } else if response_buf.len() > MAX_QUOTE_RESPONSE_HEADER_SIZE {
+                return Err(AtlsVerificationError::Io(format!(
+                    "quote response headers exceed {} bytes",
+                    MAX_QUOTE_RESPONSE_HEADER_SIZE
+                )));
             }
+        }
+
+        if expected_response_len.is_some_and(|expected| response_buf.len() >= expected) {
+            break;
         }
     }
 
@@ -704,7 +735,21 @@ where
     // Parse HTTP response
     let body_start = find_http_body_start(&response_buf)
         .ok_or_else(|| AtlsVerificationError::Io("Invalid HTTP response".into()))?;
-    let response_body = &response_buf[body_start..];
+    let content_length = parse_content_length(&response_buf[..body_start])?;
+    let expected_response_len = body_start
+        .checked_add(content_length)
+        .ok_or_else(|| AtlsVerificationError::Io("quote response length overflow".into()))?;
+    if response_buf.len() < expected_response_len {
+        return Err(AtlsVerificationError::Io(
+            "quote response ended before the declared Content-Length".into(),
+        ));
+    }
+    if response_buf.len() > expected_response_len {
+        return Err(AtlsVerificationError::Io(
+            "quote response contains data beyond the declared Content-Length".into(),
+        ));
+    }
+    let response_body = &response_buf[body_start..expected_response_len];
 
     let response: QuoteEndpointResponse = serde_json::from_slice(response_body).map_err(|e| {
         AtlsVerificationError::Quote(format!("Failed to parse /tdx_quote response: {}", e))
@@ -723,16 +768,35 @@ fn find_http_body_start(data: &[u8]) -> Option<usize> {
     None
 }
 
-/// Parse Content-Length header from HTTP response.
-fn parse_content_length(headers: &[u8]) -> Option<usize> {
-    let headers_str = std::str::from_utf8(headers).ok()?;
-    for line in headers_str.lines() {
-        if line.to_lowercase().starts_with("content-length:") {
-            let value = line.split(':').nth(1)?.trim();
-            return value.parse().ok();
+/// Parse the required, unique Content-Length header from an HTTP response.
+fn parse_content_length(headers: &[u8]) -> Result<usize, AtlsVerificationError> {
+    let headers_str = std::str::from_utf8(headers)
+        .map_err(|_| AtlsVerificationError::Io("invalid quote response headers".into()))?;
+    let mut content_length = None;
+
+    for line in headers_str.split("\r\n").skip(1) {
+        if line.is_empty() {
+            continue;
+        }
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(AtlsVerificationError::Io(
+                "invalid quote response header".into(),
+            ));
+        };
+        if name.eq_ignore_ascii_case("content-length") {
+            if content_length.is_some() {
+                return Err(AtlsVerificationError::Io(
+                    "duplicate Content-Length in quote response".into(),
+                ));
+            }
+            content_length = Some(value.trim().parse().map_err(|_| {
+                AtlsVerificationError::Io("invalid Content-Length in quote response".into())
+            })?);
         }
     }
-    None
+
+    content_length
+        .ok_or_else(|| AtlsVerificationError::Io("quote response is missing Content-Length".into()))
 }
 
 /// Authenticate RTMR3 event payloads against their logged digests.
@@ -787,6 +851,85 @@ fn verify_event_log_integrity(events: &[EventLog]) -> Result<(), AtlsVerificatio
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    async fn get_quote_from_response(
+        response: Vec<u8>,
+    ) -> Result<GetQuoteResponse, AtlsVerificationError> {
+        let capacity = response.len().max(1024) + 1024;
+        let (mut client, mut server) = tokio::io::duplex(capacity);
+        let writer = tokio::spawn(async move {
+            server.write_all(&response).await.unwrap();
+            server.shutdown().await.unwrap();
+        });
+
+        let result = get_quote_over_http(&mut client, &[0u8; 32], "example.test").await;
+        writer.await.unwrap();
+        result
+    }
+
+    #[tokio::test]
+    async fn test_quote_response_valid_content_length_success() {
+        let body = br#"{"quote":{"quote":"","event_log":""}}"#;
+        let response =
+            format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", body.len()).into_bytes();
+        let response = [response, body.to_vec()].concat();
+
+        let quote = get_quote_from_response(response).await.unwrap();
+
+        assert_eq!(quote.quote, "");
+        assert_eq!(quote.event_log, "");
+    }
+
+    #[tokio::test]
+    async fn test_quote_response_oversized_header_failure() {
+        let response = [
+            b"HTTP/1.1 200 OK\r\nX-Fill: ".as_slice(),
+            &vec![b'a'; 64 * 1024],
+        ]
+        .concat();
+
+        let error = get_quote_from_response(response).await.unwrap_err();
+
+        assert!(error.to_string().contains("quote response headers exceed"));
+    }
+
+    #[tokio::test]
+    async fn test_quote_response_oversized_body_declaration_failure() {
+        let response = b"HTTP/1.1 200 OK\r\nContent-Length: 16777217\r\n\r\n".to_vec();
+
+        let error = get_quote_from_response(response).await.unwrap_err();
+
+        assert!(error.to_string().contains("quote response body exceeds"));
+    }
+
+    #[tokio::test]
+    async fn test_quote_response_missing_content_length_failure() {
+        let response =
+            b"HTTP/1.1 200 OK\r\n\r\n{\"quote\":{\"quote\":\"\",\"event_log\":\"\"}}".to_vec();
+
+        let error = get_quote_from_response(response).await.unwrap_err();
+
+        assert!(error.to_string().contains("missing Content-Length"));
+    }
+
+    #[tokio::test]
+    async fn test_quote_response_duplicate_content_length_failure() {
+        let response =
+            b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nContent-Length: 0\r\n\r\n".to_vec();
+
+        let error = get_quote_from_response(response).await.unwrap_err();
+
+        assert!(error.to_string().contains("duplicate Content-Length"));
+    }
+
+    #[tokio::test]
+    async fn test_quote_response_truncated_body_failure() {
+        let response = b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\nshort".to_vec();
+
+        let error = get_quote_from_response(response).await.unwrap_err();
+
+        assert!(error.to_string().contains("ended before"));
+    }
 
     fn ev(imr: u32, event_type: u32, event: &str, event_payload: &str, digest: &str) -> EventLog {
         EventLog {

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -862,7 +862,9 @@ mod tests {
             server.shutdown().await.unwrap();
         });
 
-        let result = get_quote_over_http(&mut client, &[0u8; 32], "example.test").await;
+        let mut nonce = [0u8; 32];
+        rand::Rng::fill(&mut rand::thread_rng(), &mut nonce);
+        let result = get_quote_over_http(&mut client, &nonce, "example.test").await;
         writer.await.unwrap();
         result
     }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -37,6 +37,11 @@ pub enum AtlsVerificationError {
     #[error("failed to parse event log: {0}")]
     EventLogParse(String),
 
+    /// An RTMR3 event's logged digest does not match the digest recomputed from
+    /// its contents, so its `event_payload` is not authenticated by the quote.
+    #[error("event log digest mismatch for event '{event}'")]
+    EventLogDigestMismatch { event: String },
+
     /// TEE type mismatch.
     #[error("TEE type mismatch: {0}")]
     TeeTypeMismatch(String),

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -59,7 +59,10 @@ pub enum AtlsVerificationError {
 
     /// TCB status not in allowed list.
     #[error("TCB status {status} not allowed (allowed: {allowed:?})")]
-    TcbStatusNotAllowed { status: String, allowed: Vec<String> },
+    TcbStatusNotAllowed {
+        status: String,
+        allowed: Vec<String>,
+    },
 
     /// TCB info could not be determined or parsed.
     #[error("TCB info error: {0}")]
@@ -74,7 +77,9 @@ pub enum AtlsVerificationError {
     },
 
     /// Report data mismatch - potential replay attack.
-    #[error("report data mismatch: expected {expected}, got {actual}. Possible replay/relay attack.")]
+    #[error(
+        "report data mismatch: expected {expected}, got {actual}. Possible replay/relay attack."
+    )]
     ReportDataMismatch { expected: String, actual: String },
 
     /// Configuration error.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -95,7 +95,9 @@ pub use policy::Policy;
 
 // Dstack-specific (backward compatible re-exports)
 // NOTE: compose_hash NOT exposed at root - access via dstack::compose_hash
-pub use dstack::{DstackTDXVerifier, DstackTDXVerifierBuilder, DstackTDXVerifierConfig, DstackTdxPolicy};
+pub use dstack::{
+    DstackTDXVerifier, DstackTDXVerifierBuilder, DstackTDXVerifierConfig, DstackTdxPolicy,
+};
 
 // Generic TDX
 pub use tdx::{ExpectedBootchain, TCB_STATUS_LIST};
@@ -103,8 +105,8 @@ pub use tdx::{ExpectedBootchain, TCB_STATUS_LIST};
 // Low-level API
 pub use error::AtlsVerificationError;
 pub use verifier::{
-    AsyncByteStream, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, IntoVerifier, AtlsVerifier,
-    Report, Verifier,
+    AsyncByteStream, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, AtlsVerifier,
+    IntoVerifier, Report, Verifier,
 };
 
 // Re-export VerifiedReport from dcap-qvl for bindings

--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -41,6 +41,14 @@ impl Default for Policy {
 }
 
 impl Policy {
+    /// Whether the policy accepts self-signed server certificates (skipping CA
+    /// chain, hostname, and expiry validation) during the TLS handshake.
+    pub fn accept_self_signed_certs(&self) -> bool {
+        match self {
+            Policy::DstackTdx(policy) => policy.accept_self_signed_certs,
+        }
+    }
+
     /// Convert this policy into its corresponding verifier.
     ///
     /// This delegates to the underlying policy variant's [`IntoVerifier`] implementation,

--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -64,9 +64,7 @@ impl Policy {
     /// ```
     pub fn into_verifier(self) -> Result<Verifier, AtlsVerificationError> {
         match self {
-            Policy::DstackTdx(policy) => {
-                Ok(Verifier::DstackTdx(policy.into_verifier()?))
-            }
+            Policy::DstackTdx(policy) => Ok(Verifier::DstackTdx(policy.into_verifier()?)),
         }
     }
 }
@@ -91,7 +89,9 @@ mod tests {
         let policy = Policy::DstackTdx(DstackTdxPolicy::dev());
         match policy {
             Policy::DstackTdx(tdx) => {
-                assert!(tdx.allowed_tcb_status.contains(&"SWHardeningNeeded".to_string()));
+                assert!(tdx
+                    .allowed_tcb_status
+                    .contains(&"SWHardeningNeeded".to_string()));
             }
         }
     }

--- a/core/src/tdx/grace_period.rs
+++ b/core/src/tdx/grace_period.rs
@@ -3,8 +3,8 @@
 use chrono::DateTime;
 use dcap_qvl::intel::parse_pck_extension;
 use dcap_qvl::quote::Quote;
-use dcap_qvl::QuoteCollateralV3;
 use dcap_qvl::verify::VerifiedReport;
+use dcap_qvl::QuoteCollateralV3;
 use pem::parse_many;
 use serde::Deserialize;
 
@@ -40,13 +40,11 @@ fn evaluate_grace_period(
     now_secs: u64,
     grace: u64,
 ) -> Result<(), AtlsVerificationError> {
-    let now_secs = i64::try_from(now_secs).map_err(|_| {
-        AtlsVerificationError::TcbInfoError("current time out of range".into())
-    })?;
+    let now_secs = i64::try_from(now_secs)
+        .map_err(|_| AtlsVerificationError::TcbInfoError("current time out of range".into()))?;
 
-    let grace_secs = i64::try_from(grace).map_err(|_| {
-        AtlsVerificationError::Configuration("grace_period is too large".into())
-    })?;
+    let grace_secs = i64::try_from(grace)
+        .map_err(|_| AtlsVerificationError::Configuration("grace_period is too large".into()))?;
     let expiration = tcb_date_secs.checked_add(grace_secs).ok_or_else(|| {
         AtlsVerificationError::Configuration("grace_period causes timestamp overflow".into())
     })?;
@@ -136,9 +134,7 @@ fn extract_pck_leaf_cert(
     if let Some(pem_chain) = &collateral.pck_certificate_chain {
         let certs = parse_pem_chain(pem_chain)?;
         return certs.first().cloned().ok_or_else(|| {
-            AtlsVerificationError::TcbInfoError(
-                "PCK certificate chain is empty".to_string(),
-            )
+            AtlsVerificationError::TcbInfoError("PCK certificate chain is empty".to_string())
         });
     }
 
@@ -156,17 +152,17 @@ fn extract_pck_leaf_cert(
 
 fn parse_pem_chain(pem_chain: &str) -> Result<Vec<Vec<u8>>, AtlsVerificationError> {
     let certs = parse_many(pem_chain).map_err(|e| {
-        AtlsVerificationError::TcbInfoError(format!(
-            "failed to parse PCK certificate chain: {}",
-            e
-        ))
+        AtlsVerificationError::TcbInfoError(format!("failed to parse PCK certificate chain: {}", e))
     })?;
     if certs.is_empty() {
         return Err(AtlsVerificationError::TcbInfoError(
             "failed to parse PCK certificate chain".to_string(),
         ));
     }
-    Ok(certs.into_iter().map(|pem| pem.contents().to_vec()).collect())
+    Ok(certs
+        .into_iter()
+        .map(|pem| pem.contents().to_vec())
+        .collect())
 }
 
 fn match_tcb_level<'a>(
@@ -211,8 +207,7 @@ fn match_tcb_level<'a>(
             continue;
         }
 
-        let sgx_components: Vec<u8> =
-            tcb_level.tcb.sgx_components.iter().map(|c| c.svn).collect();
+        let sgx_components: Vec<u8> = tcb_level.tcb.sgx_components.iter().map(|c| c.svn).collect();
         if sgx_components.is_empty() {
             return Err(AtlsVerificationError::TcbInfoError(
                 "no SGX components in TCB info".into(),
@@ -256,13 +251,7 @@ mod tests {
 
     #[test]
     fn test_grace_period_expired() {
-        let result = evaluate_grace_period(
-            "OutOfDate",
-            100,
-            "2024-01-01T00:00:00Z",
-            200,
-            50,
-        );
+        let result = evaluate_grace_period("OutOfDate", 100, "2024-01-01T00:00:00Z", 200, 50);
 
         assert!(matches!(
             result,
@@ -272,26 +261,14 @@ mod tests {
 
     #[test]
     fn test_grace_period_allows_within_window() {
-        let result = evaluate_grace_period(
-            "OutOfDate",
-            100,
-            "2024-01-01T00:00:00Z",
-            120,
-            50,
-        );
+        let result = evaluate_grace_period("OutOfDate", 100, "2024-01-01T00:00:00Z", 120, 50);
 
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_grace_period_zero_expires_immediately() {
-        let result = evaluate_grace_period(
-            "OutOfDate",
-            100,
-            "2024-01-01T00:00:00Z",
-            101,
-            0,
-        );
+        let result = evaluate_grace_period("OutOfDate", 100, "2024-01-01T00:00:00Z", 101, 0);
 
         assert!(matches!(
             result,

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -149,7 +149,9 @@ pub trait IntoVerifier {
 /// let verifier = policy.into_verifier().unwrap();
 ///
 /// // The verifier can be used with any async stream
-/// // verifier.verify(&mut stream, &peer_cert, hostname).await
+/// // verifier
+/// //     .verify(&mut stream, &peer_cert, &session_ekm, hostname)
+/// //     .await
 /// ```
 pub enum Verifier {
     /// DStack TDX verifier.
@@ -158,40 +160,36 @@ pub enum Verifier {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl AtlsVerifier for Verifier {
-    fn verify<S>(
+    async fn verify<S>(
         &self,
         stream: &mut S,
         peer_cert: &[u8],
         session_ekm: &[u8],
         hostname: &str,
-    ) -> impl Future<Output = Result<Report, AtlsVerificationError>> + Send
+    ) -> Result<Report, AtlsVerificationError>
     where
         S: AsyncByteStream,
     {
-        async move {
-            match self {
-                Verifier::DstackTdx(v) => v.verify(stream, peer_cert, session_ekm, hostname).await,
-            }
+        match self {
+            Verifier::DstackTdx(v) => v.verify(stream, peer_cert, session_ekm, hostname).await,
         }
     }
 }
 
 #[cfg(target_arch = "wasm32")]
 impl AtlsVerifier for Verifier {
-    fn verify<S>(
+    async fn verify<S>(
         &self,
         stream: &mut S,
         peer_cert: &[u8],
         session_ekm: &[u8],
         hostname: &str,
-    ) -> impl Future<Output = Result<Report, AtlsVerificationError>>
+    ) -> Result<Report, AtlsVerificationError>
     where
         S: AsyncByteStream,
     {
-        async move {
-            match self {
-                Verifier::DstackTdx(v) => v.verify(stream, peer_cert, session_ekm, hostname).await,
-            }
+        match self {
+            Verifier::DstackTdx(v) => v.verify(stream, peer_cert, session_ekm, hostname).await,
         }
     }
 }

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -3,7 +3,8 @@
 //! These tests verify real TDX attestation against a live dstack deployment.
 
 use atlas_rs::{
-    DstackTDXVerifierBuilder, ExpectedBootchain, AtlsVerificationError, dstack::{compose_hash::get_compose_hash, get_default_app_compose}
+    dstack::{compose_hash::get_compose_hash, get_default_app_compose},
+    AtlsVerificationError, DstackTDXVerifierBuilder, ExpectedBootchain,
 };
 use serde_json::json;
 
@@ -13,8 +14,7 @@ const TEST_HOST: &str = "vllm.concrete-security.com";
 /// OS image hash for testing.
 /// This is the hash observed in production for vllm.concrete-security.com
 /// and should be updated if the OS image changes.
-const TEST_OS_IMAGE_HASH: &str =
-    "86b181377635db21c415f9ece8cc8505f7d4936ad3be7043969005a8c4690c1a";
+const TEST_OS_IMAGE_HASH: &str = "86b181377635db21c415f9ece8cc8505f7d4936ad3be7043969005a8c4690c1a";
 
 /// Bootchain measurements for testing (Dstack 0.5.4.1-nvidia).
 fn test_bootchain() -> ExpectedBootchain {
@@ -92,7 +92,10 @@ fn test_builder_complete_config() {
         .app_compose(app_compose)
         .expected_bootchain(test_bootchain())
         .os_image_hash(TEST_OS_IMAGE_HASH)
-        .allowed_tcb_status(vec!["UpToDate".to_string(), "SWHardeningNeeded".to_string()])
+        .allowed_tcb_status(vec![
+            "UpToDate".to_string(),
+            "SWHardeningNeeded".to_string(),
+        ])
         .cache_collateral(true)
         .build();
 
@@ -118,15 +121,15 @@ fn test_expected_bootchain_values() {
 
 mod integration {
     use super::*;
+    use atlas_rs::tdx::grace_period::enforce_grace_period;
     use atlas_rs::AtlsVerifier;
     use atlas_rs::{DstackTdxPolicy, Policy};
-    use atlas_rs::tdx::grace_period::enforce_grace_period;
     use dcap_qvl::collateral::get_collateral;
     use dcap_qvl::quote::Quote;
     use dcap_qvl::verify::verify;
     use dstack_sdk_types::dstack::GetQuoteResponse;
-    use rustls::pki_types::ServerName;
     use rustls::crypto::ring::default_provider;
+    use rustls::pki_types::ServerName;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::net::TcpStream;
@@ -141,7 +144,10 @@ mod integration {
     /// Establish an async TLS connection and return the stream, peer certificate, and session EKM.
     async fn connect_tls(
         host: &str,
-    ) -> Result<(tokio_rustls::client::TlsStream<TcpStream>, Vec<u8>, Vec<u8>), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<
+        (tokio_rustls::client::TlsStream<TcpStream>, Vec<u8>, Vec<u8>),
+        Box<dyn std::error::Error + Send + Sync>,
+    > {
         // Ensure crypto provider is installed
         ensure_crypto_provider();
 
@@ -160,7 +166,9 @@ mod integration {
         let tcp_stream = TcpStream::connect(format!("{}:443", host)).await?;
 
         // Complete TLS handshake
-        let stream = connector.connect(server_name.to_owned(), tcp_stream).await?;
+        let stream = connector
+            .connect(server_name.to_owned(), tcp_stream)
+            .await?;
 
         // Get peer certificate and extract session EKM
         let (_, conn) = stream.get_ref();
@@ -217,15 +225,14 @@ mod integration {
             .build()
             .expect("Failed to build verifier");
 
-        let (mut stream, peer_cert, session_ekm) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
+        let (mut stream, peer_cert, session_ekm) =
+            connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
 
-        let result = verifier.verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST).await;
+        let result = verifier
+            .verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST)
+            .await;
 
-        assert!(
-            result.is_ok(),
-            "Verification failed: {:?}",
-            result.err()
-        );
+        assert!(result.is_ok(), "Verification failed: {:?}", result.err());
         let report = result.unwrap();
         match &report {
             atlas_rs::Report::Tdx(tdx_report) => {
@@ -246,10 +253,7 @@ mod integration {
 
         let policy = Policy::DstackTdx(DstackTdxPolicy {
             grace_period: Some(0),
-            allowed_tcb_status: vec![
-                "UpToDate".to_string(),
-                "OutOfDate".to_string(),
-            ],
+            allowed_tcb_status: vec!["UpToDate".to_string(), "OutOfDate".to_string()],
             disable_runtime_verification: true,
             ..Default::default()
         });
@@ -278,48 +282,60 @@ mod integration {
             .expect("Failed to decode quote");
         let quote = Quote::parse(&quote_bytes).expect("Failed to parse quote");
 
-        let collateral = get_collateral(
-            atlas_rs::dstack::policy::DEFAULT_PCCS_URL,
-            &quote_bytes,
-        )
-        .await
-        .expect("Failed to fetch collateral");
+        let collateral = get_collateral(atlas_rs::dstack::policy::DEFAULT_PCCS_URL, &quote_bytes)
+            .await
+            .expect("Failed to fetch collateral");
 
         let now_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards")
             .as_secs();
 
-        let report = verify(&quote_bytes, &collateral, now_secs)
-            .expect("DCAP verification failed");
+        let report = verify(&quote_bytes, &collateral, now_secs).expect("DCAP verification failed");
 
         if report.status == "OutOfDate" {
             // Platform is actually OutOfDate — test both paths.
 
             // Valid window: use a time before the TCB date to guarantee success.
             let valid = enforce_grace_period(&report, &quote, &collateral, Some(0), 0);
-            assert!(valid.is_ok(), "Expected grace period to be valid, got: {:?}", valid);
+            assert!(
+                valid.is_ok(),
+                "Expected grace period to be valid, got: {:?}",
+                valid
+            );
             // Same as above but with a non-zero grace period
-            let valid = enforce_grace_period(&report, &quote, &collateral, Some(60*60*24), 0);
-            assert!(valid.is_ok(), "Expected grace period to be valid, got: {:?}", valid);
+            let valid = enforce_grace_period(&report, &quote, &collateral, Some(60 * 60 * 24), 0);
+            assert!(
+                valid.is_ok(),
+                "Expected grace period to be valid, got: {:?}",
+                valid
+            );
 
             // Expired window: use a far-future time to guarantee expiration.
             let expired = enforce_grace_period(
                 &report,
                 &quote,
                 &collateral,
-                Some(3600 * 24 * 30), // 30 days grace period
+                Some(3600 * 24 * 30),   // 30 days grace period
                 (i64::MAX / 16) as u64, // div 16 to avoid overflow
             );
             assert!(
-                matches!(expired, Err(AtlsVerificationError::GracePeriodExpired { .. })),
+                matches!(
+                    expired,
+                    Err(AtlsVerificationError::GracePeriodExpired { .. })
+                ),
                 "Expected GracePeriodExpired, got: {:?}",
                 expired
             );
         } else {
             // Platform is not OutOfDate — grace period is a no-op regardless of config.
             let result = enforce_grace_period(&report, &quote, &collateral, Some(0), 0);
-            assert!(result.is_ok(), "Grace period should be no-op for status '{}', got: {:?}", report.status, result);
+            assert!(
+                result.is_ok(),
+                "Grace period should be no-op for status '{}', got: {:?}",
+                report.status,
+                result
+            );
         }
     }
 
@@ -345,20 +361,24 @@ mod integration {
             .build()
             .expect("Failed to build verifier");
 
-        let (mut stream, peer_cert, session_ekm) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
+        let (mut stream, peer_cert, session_ekm) =
+            connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
 
-        let result = verifier.verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST).await;
+        let result = verifier
+            .verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST)
+            .await;
 
         // This might fail if app_compose doesn't match - that's expected
         // The important thing is that the verifier runs the full verification
         match &result {
-            Ok(report) => {
-                match report {
-                    atlas_rs::Report::Tdx(tdx_report) => {
-                        println!("Full verification passed! TCB Status: {}", tdx_report.status);
-                    }
+            Ok(report) => match report {
+                atlas_rs::Report::Tdx(tdx_report) => {
+                    println!(
+                        "Full verification passed! TCB Status: {}",
+                        tdx_report.status
+                    );
                 }
-            }
+            },
             Err(e) => {
                 panic!("Unexpected verification error: {:?}", e);
             }
@@ -390,9 +410,12 @@ mod integration {
             .build()
             .expect("Failed to build verifier");
 
-        let (mut stream, peer_cert, session_ekm) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
+        let (mut stream, peer_cert, session_ekm) =
+            connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
 
-        let result = verifier.verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST).await;
+        let result = verifier
+            .verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST)
+            .await;
 
         assert!(
             matches!(result, Err(AtlsVerificationError::BootchainMismatch { .. })),
@@ -426,9 +449,12 @@ mod integration {
             .build()
             .expect("Failed to build verifier");
 
-        let (mut stream, peer_cert, session_ekm) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
+        let (mut stream, peer_cert, session_ekm) =
+            connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
 
-        let result = verifier.verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST).await;
+        let result = verifier
+            .verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST)
+            .await;
 
         // The verifier should fail with either AppComposeHashMismatch (if compose doesn't match)
         // or OsImageHashMismatch (if compose matches but OS hash doesn't)
@@ -460,14 +486,30 @@ mod integration {
             .expect("Failed to build verifier");
 
         // First verification
-        let (mut stream1, peer_cert1, session_ekm1) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS (1)");
-        let result1 = verifier.verify(&mut stream1, &peer_cert1, &session_ekm1, TEST_HOST).await;
-        assert!(result1.is_ok(), "First verification failed: {:?}", result1.err());
+        let (mut stream1, peer_cert1, session_ekm1) = connect_tls(TEST_HOST)
+            .await
+            .expect("Failed to connect TLS (1)");
+        let result1 = verifier
+            .verify(&mut stream1, &peer_cert1, &session_ekm1, TEST_HOST)
+            .await;
+        assert!(
+            result1.is_ok(),
+            "First verification failed: {:?}",
+            result1.err()
+        );
 
         // Second verification (should use cached collateral)
-        let (mut stream2, peer_cert2, session_ekm2) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS (2)");
-        let result2 = verifier.verify(&mut stream2, &peer_cert2, &session_ekm2, TEST_HOST).await;
-        assert!(result2.is_ok(), "Second verification failed: {:?}", result2.err());
+        let (mut stream2, peer_cert2, session_ekm2) = connect_tls(TEST_HOST)
+            .await
+            .expect("Failed to connect TLS (2)");
+        let result2 = verifier
+            .verify(&mut stream2, &peer_cert2, &session_ekm2, TEST_HOST)
+            .await;
+        assert!(
+            result2.is_ok(),
+            "Second verification failed: {:?}",
+            result2.err()
+        );
 
         println!("Multiple verifications with same verifier instance passed!");
     }
@@ -487,14 +529,30 @@ mod integration {
             .expect("Failed to build verifier");
 
         // First verification - fetches collateral from PCCS
-        let (mut stream1, peer_cert1, session_ekm1) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS (1)");
-        let result1 = verifier.verify(&mut stream1, &peer_cert1, &session_ekm1, TEST_HOST).await;
-        assert!(result1.is_ok(), "First verification failed: {:?}", result1.err());
+        let (mut stream1, peer_cert1, session_ekm1) = connect_tls(TEST_HOST)
+            .await
+            .expect("Failed to connect TLS (1)");
+        let result1 = verifier
+            .verify(&mut stream1, &peer_cert1, &session_ekm1, TEST_HOST)
+            .await;
+        assert!(
+            result1.is_ok(),
+            "First verification failed: {:?}",
+            result1.err()
+        );
 
         // Second verification - uses cached collateral
-        let (mut stream2, peer_cert2, session_ekm2) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS (2)");
-        let result2 = verifier.verify(&mut stream2, &peer_cert2, &session_ekm2, TEST_HOST).await;
-        assert!(result2.is_ok(), "Second verification (cached) failed: {:?}", result2.err());
+        let (mut stream2, peer_cert2, session_ekm2) = connect_tls(TEST_HOST)
+            .await
+            .expect("Failed to connect TLS (2)");
+        let result2 = verifier
+            .verify(&mut stream2, &peer_cert2, &session_ekm2, TEST_HOST)
+            .await;
+        assert!(
+            result2.is_ok(),
+            "Second verification (cached) failed: {:?}",
+            result2.err()
+        );
 
         println!("Collateral caching test passed!");
     }
@@ -522,7 +580,9 @@ mod integration {
         // Run the async verification using block_on
         let result = rt.block_on(async {
             let (mut stream, peer_cert, session_ekm) = connect_tls(TEST_HOST).await?;
-            verifier.verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST).await
+            verifier
+                .verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST)
+                .await
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
         });
 
@@ -551,10 +611,7 @@ mod integration {
             expected_bootchain: Some(test_bootchain()),
             app_compose: Some(app_compose),
             os_image_hash: Some(TEST_OS_IMAGE_HASH.to_string()),
-            allowed_tcb_status: vec![
-                "UpToDate".to_string(),
-                "SWHardeningNeeded".to_string(),
-            ],
+            allowed_tcb_status: vec!["UpToDate".to_string(), "SWHardeningNeeded".to_string()],
             ..Default::default()
         });
         let result = atlas_rs::atls_connect(tcp, TEST_HOST, policy, None).await;
@@ -562,13 +619,14 @@ mod integration {
         // This might fail if app_compose doesn't match - that's expected
         // The important thing is that the verifier runs the full verification
         match &result {
-            Ok((_, report)) => {
-                match report {
-                    atlas_rs::Report::Tdx(tdx_report) => {
-                        println!("atls_connect full verification passed! TCB Status: {}", tdx_report.status);
-                    }
+            Ok((_, report)) => match report {
+                atlas_rs::Report::Tdx(tdx_report) => {
+                    println!(
+                        "atls_connect full verification passed! TCB Status: {}",
+                        tdx_report.status
+                    );
                 }
-            }
+            },
             Err(e) => {
                 panic!("Unexpected verification error: {:?}", e);
             }
@@ -591,28 +649,22 @@ mod integration {
             expected_bootchain: Some(test_bootchain()),
             app_compose: Some(app_compose),
             os_image_hash: Some(TEST_OS_IMAGE_HASH.to_string()),
-            allowed_tcb_status: vec![
-                "UpToDate".to_string(),
-                "SWHardeningNeeded".to_string(),
-            ],
+            allowed_tcb_status: vec!["UpToDate".to_string(), "SWHardeningNeeded".to_string()],
             ..Default::default()
         });
-        let result = atlas_rs::atls_connect(
-            tcp,
-            TEST_HOST,
-            policy,
-            Some(vec!["http/1.1".into()]),
-        ).await;
+        let result =
+            atlas_rs::atls_connect(tcp, TEST_HOST, policy, Some(vec!["http/1.1".into()])).await;
 
         // This might fail if app_compose doesn't match - that's expected
         match &result {
-            Ok((_, report)) => {
-                match report {
-                    atlas_rs::Report::Tdx(tdx_report) => {
-                        println!("atls_connect with ALPN passed! TCB Status: {}", tdx_report.status);
-                    }
+            Ok((_, report)) => match report {
+                atlas_rs::Report::Tdx(tdx_report) => {
+                    println!(
+                        "atls_connect with ALPN passed! TCB Status: {}",
+                        tdx_report.status
+                    );
                 }
-            }
+            },
             Err(e) => {
                 panic!("Unexpected verification error: {:?}", e);
             }
@@ -629,15 +681,18 @@ mod integration {
 
         let result = atlas_rs::connect::tls_handshake(tcp, TEST_HOST, None, false).await;
 
-        assert!(
-            result.is_ok(),
-            "tls_handshake failed: {:?}",
-            result.err()
-        );
+        assert!(result.is_ok(), "tls_handshake failed: {:?}", result.err());
 
         let (_, peer_cert, session_ekm) = result.unwrap();
-        assert!(!peer_cert.is_empty(), "Peer certificate should not be empty");
+        assert!(
+            !peer_cert.is_empty(),
+            "Peer certificate should not be empty"
+        );
         assert_eq!(session_ekm.len(), 32, "Session EKM should be 32 bytes");
-        println!("tls_handshake passed! Cert size: {} bytes, EKM: {} bytes", peer_cert.len(), session_ekm.len());
+        println!(
+            "tls_handshake passed! Cert size: {} bytes, EKM: {} bytes",
+            peer_cert.len(),
+            session_ekm.len()
+        );
     }
 }

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -627,7 +627,7 @@ mod integration {
             .await
             .expect("Failed to connect TCP");
 
-        let result = atlas_rs::connect::tls_handshake(tcp, TEST_HOST, None).await;
+        let result = atlas_rs::connect::tls_handshake(tcp, TEST_HOST, None, false).await;
 
         assert!(
             result.is_ok(),

--- a/node/atls-fetch.d.ts
+++ b/node/atls-fetch.d.ts
@@ -44,6 +44,11 @@ export interface DstackTdxPolicy {
   expected_bootchain?: ExpectedBootchain
   /** Expected OS image hash (SHA256, hex-encoded) */
   os_image_hash?: string
+  /**
+   * Expected RTMR3 — the full runtime measurement register (96 lowercase hex
+   * chars). Pins the whole runtime event sequence; omit to skip the check.
+   */
+  expected_rtmr3?: string
   /** Expected app compose configuration */
   app_compose?: AppCompose
   /** Allowed TCB status values (default: ["UpToDate"]) */
@@ -60,6 +65,13 @@ export interface DstackTdxPolicy {
    * Set to true only for development/testing.
    */
   disable_runtime_verification?: boolean
+  /**
+   * Accept a self-signed server certificate, skipping CA chain, hostname/SAN,
+   * and expiry validation (for TEEs that serve self-signed certs). Defaults to
+   * false. Cannot be combined with disable_runtime_verification. Pair with
+   * expected_rtmr3 to bind the specific instance.
+   */
+  accept_self_signed_certs?: boolean
 }
 
 /**

--- a/node/atls-fetch.d.ts
+++ b/node/atls-fetch.d.ts
@@ -68,8 +68,8 @@ export interface DstackTdxPolicy {
   /**
    * Accept a self-signed server certificate, skipping CA chain, hostname/SAN,
    * and expiry validation (for TEEs that serve self-signed certs). Defaults to
-   * false. Cannot be combined with disable_runtime_verification. Pair with
-   * expected_rtmr3 to bind the specific instance.
+   * false. Requires expected_rtmr3 to bind the specific instance and cannot be
+   * combined with disable_runtime_verification.
    */
   accept_self_signed_certs?: boolean
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,11 +1,11 @@
+use atlas_rs::{
+    atls_connect as core_atls_connect, dstack::merge_with_default_app_compose, Policy, Report,
+    TlsStream as CoreTlsStream,
+};
 use bytes::{Bytes, BytesMut};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use once_cell::sync::Lazy;
-use atlas_rs::{
-    dstack::merge_with_default_app_compose, atls_connect as core_atls_connect, Policy, Report,
-    TlsStream as CoreTlsStream,
-};
 use rustls::crypto::aws_lc_rs::default_provider;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -97,14 +97,9 @@ pub async fn atls_connect(
         .await
         .map_err(|err| Error::from_reason(format!("tcp connect failed: {err}")))?;
 
-    let (tls, report) = core_atls_connect(
-        tcp,
-        &server_name,
-        policy,
-        Some(vec!["http/1.1".into()]),
-    )
-    .await
-    .map_err(|err| Error::from_reason(format!("atls handshake failed: {err}")))?;
+    let (tls, report) = core_atls_connect(tcp, &server_name, policy, Some(vec!["http/1.1".into()]))
+        .await
+        .map_err(|err| Error::from_reason(format!("atls handshake failed: {err}")))?;
 
     let socket_id = NEXT_SOCKET_ID.fetch_add(1, Ordering::SeqCst);
     let (reader, writer) = tokio::io::split(tls);
@@ -165,10 +160,12 @@ pub async fn socket_write(socket_id: u32, data: Buffer) -> napi::Result<u32> {
     let bytes = Bytes::from(data.to_vec());
     {
         let mut writer = writer.lock().await;
-        writer.write_all(&bytes)
+        writer
+            .write_all(&bytes)
             .await
             .map_err(|e| Error::from_reason(format!("socket write error: {e}")))?;
-        writer.flush()
+        writer
+            .flush()
             .await
             .map_err(|e| Error::from_reason(format!("socket flush error: {e}")))?;
     }

--- a/python/README.md
+++ b/python/README.md
@@ -69,7 +69,7 @@ from atlas.httpx import Client
 client = Client(atls_policy_per_hostname={"host.com": policy})
 ```
 
-### `atlas.policy.dstack_tdx_policy(**kwargs)`
+### `atlas.policy.dstack_tdx_policy(...)`
 
 Build a DStack TDX attestation policy dict
 
@@ -84,6 +84,12 @@ Build a DStack TDX attestation policy dict
 | `app_compose_allowed_envs` | `list[str] \| None` | Override `allowed_envs` in app_compose |
 | `pccs_url` | `str \| None` | Intel PCCS URL for collateral |
 | `cache_collateral` | `bool` | Cache Intel collateral between verifications |
+| `expected_rtmr3` | `str` | Keyword-only 96-character lowercase RTMR3 pin; required for self-signed mode |
+| `accept_self_signed_certs` | `bool` | Keyword-only self-signed TLS mode; requires `expected_rtmr3` and full runtime verification |
+
+The original nine parameters retain their positional order for compatibility.
+New security options are keyword-only so adding them cannot silently remap an
+existing caller's policy.
 
 ### `atlas.policy.dev_policy()`
 

--- a/python/src/atlas/policy.py
+++ b/python/src/atlas/policy.py
@@ -33,8 +33,10 @@ def dstack_tdx_policy(
     app_compose: Optional[dict] = None,
     expected_bootchain: Optional[dict] = None,
     os_image_hash: Optional[str] = None,
+    expected_rtmr3: Optional[str] = None,
     allowed_tcb_status: Optional[list[str]] = None,
     disable_runtime_verification: bool = False,
+    accept_self_signed_certs: bool = False,
     app_compose_docker_compose_file: Optional[str] = None,
     app_compose_allowed_envs: Optional[list[str]] = None,
     pccs_url: Optional[str] = None,
@@ -55,8 +57,14 @@ def dstack_tdx_policy(
             Must be used together with ``expected_bootchain``.
         allowed_tcb_status: List of acceptable TCB status values.
             Defaults to ``["UpToDate"]``.
+        expected_rtmr3: Expected RTMR3 (96 lowercase hex chars). Pins the full
+            runtime measurement register; omit to skip the check.
         disable_runtime_verification: Skip runtime checks (bootchain,
             app_compose, os_image_hash). NOT recommended for production.
+        accept_self_signed_certs: Accept a self-signed server certificate,
+            skipping CA chain, hostname, and expiry validation (for TEEs that
+            serve self-signed certs). Cannot be combined with
+            ``disable_runtime_verification``.
         app_compose_docker_compose_file: Override the ``docker_compose_file``
             key in app_compose.
         app_compose_allowed_envs: Override the ``allowed_envs`` key in
@@ -76,6 +84,12 @@ def dstack_tdx_policy(
             "expected_bootchain and os_image_hash must be provided together"
         )
 
+    if accept_self_signed_certs and disable_runtime_verification:
+        raise ValueError(
+            "accept_self_signed_certs cannot be combined with "
+            "disable_runtime_verification"
+        )
+
     if allowed_tcb_status is None:
         allowed_tcb_status = ["UpToDate"]
 
@@ -85,6 +99,9 @@ def dstack_tdx_policy(
         "cache_collateral": cache_collateral,
         "disable_runtime_verification": disable_runtime_verification,
     }
+
+    if accept_self_signed_certs:
+        policy["accept_self_signed_certs"] = True
 
     if pccs_url is not None:
         policy["pccs_url"] = pccs_url
@@ -107,6 +124,8 @@ def dstack_tdx_policy(
             policy["expected_bootchain"] = expected_bootchain
         if os_image_hash is not None:
             policy["os_image_hash"] = os_image_hash
+        if expected_rtmr3 is not None:
+            policy["expected_rtmr3"] = expected_rtmr3
 
     return policy
 

--- a/python/src/atlas/policy.py
+++ b/python/src/atlas/policy.py
@@ -33,14 +33,15 @@ def dstack_tdx_policy(
     app_compose: Optional[dict] = None,
     expected_bootchain: Optional[dict] = None,
     os_image_hash: Optional[str] = None,
-    expected_rtmr3: Optional[str] = None,
     allowed_tcb_status: Optional[list[str]] = None,
     disable_runtime_verification: bool = False,
-    accept_self_signed_certs: bool = False,
     app_compose_docker_compose_file: Optional[str] = None,
     app_compose_allowed_envs: Optional[list[str]] = None,
     pccs_url: Optional[str] = None,
     cache_collateral: bool = False,
+    *,
+    expected_rtmr3: Optional[str] = None,
+    accept_self_signed_certs: bool = False,
 ) -> dict:
     """Build a DstackTdx attestation policy dict.
 
@@ -57,20 +58,20 @@ def dstack_tdx_policy(
             Must be used together with ``expected_bootchain``.
         allowed_tcb_status: List of acceptable TCB status values.
             Defaults to ``["UpToDate"]``.
-        expected_rtmr3: Expected RTMR3 (96 lowercase hex chars). Pins the full
-            runtime measurement register; omit to skip the check.
         disable_runtime_verification: Skip runtime checks (bootchain,
             app_compose, os_image_hash). NOT recommended for production.
-        accept_self_signed_certs: Accept a self-signed server certificate,
-            skipping CA chain, hostname, and expiry validation (for TEEs that
-            serve self-signed certs). Requires ``expected_rtmr3`` and cannot be
-            combined with ``disable_runtime_verification``.
         app_compose_docker_compose_file: Override the ``docker_compose_file``
             key in app_compose.
         app_compose_allowed_envs: Override the ``allowed_envs`` key in
             app_compose.
         pccs_url: PCCS URL for Intel collateral fetching.
         cache_collateral: Cache Intel collateral between verifications.
+        expected_rtmr3: Keyword-only expected RTMR3 (96 lowercase hex chars).
+            Pins the full runtime measurement register; omit to skip the check.
+        accept_self_signed_certs: Keyword-only self-signed certificate mode.
+            Skips CA chain, hostname, and expiry validation, requires
+            ``expected_rtmr3``, and cannot be combined with
+            ``disable_runtime_verification``.
 
     Returns:
         Policy dict like ``{"type": "dstack_tdx", ...}``.

--- a/python/src/atlas/policy.py
+++ b/python/src/atlas/policy.py
@@ -63,8 +63,8 @@ def dstack_tdx_policy(
             app_compose, os_image_hash). NOT recommended for production.
         accept_self_signed_certs: Accept a self-signed server certificate,
             skipping CA chain, hostname, and expiry validation (for TEEs that
-            serve self-signed certs). Cannot be combined with
-            ``disable_runtime_verification``.
+            serve self-signed certs). Requires ``expected_rtmr3`` and cannot be
+            combined with ``disable_runtime_verification``.
         app_compose_docker_compose_file: Override the ``docker_compose_file``
             key in app_compose.
         app_compose_allowed_envs: Override the ``allowed_envs`` key in
@@ -89,6 +89,8 @@ def dstack_tdx_policy(
             "accept_self_signed_certs cannot be combined with "
             "disable_runtime_verification"
         )
+    if accept_self_signed_certs and expected_rtmr3 is None:
+        raise ValueError("accept_self_signed_certs requires expected_rtmr3")
 
     if allowed_tcb_status is None:
         allowed_tcb_status = ["UpToDate"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -52,10 +52,7 @@ impl From<Report> for Attestation {
     fn from(report: Report) -> Self {
         match report {
             Report::Tdx(verified) => {
-                let measurement = verified
-                    .report
-                    .as_td10()
-                    .map(|td| hex::encode(td.mr_td));
+                let measurement = verified.report.as_td10().map(|td| hex::encode(td.mr_td));
                 Self {
                     trusted: true,
                     tee_type: "tdx".to_string(),

--- a/python/tests/test_policy.py
+++ b/python/tests/test_policy.py
@@ -60,6 +60,31 @@ class TestDstackTdxPolicy:
         )
         assert policy["pccs_url"] == "https://custom-pccs.example.com"
 
+    def test_dstack_tdx_policy_legacy_positional_compatibility(
+        self, bootchain, os_image_hash
+    ):
+        """The established nine positional arguments retain their original mapping."""
+        policy = dstack_tdx_policy(
+            {"docker_compose_file": "base", "allowed_envs": []},
+            bootchain,
+            os_image_hash,
+            ["UpToDate", "OutOfDate"],
+            False,
+            "legacy-compose",
+            ["LEGACY_SECRET"],
+            "https://legacy-pccs.example.com",
+            True,
+        )
+
+        assert policy["allowed_tcb_status"] == ["UpToDate", "OutOfDate"]
+        assert policy["disable_runtime_verification"] is False
+        assert policy["app_compose"]["docker_compose_file"] == "legacy-compose"
+        assert policy["app_compose"]["allowed_envs"] == ["LEGACY_SECRET"]
+        assert policy["pccs_url"] == "https://legacy-pccs.example.com"
+        assert policy["cache_collateral"] is True
+        assert "expected_rtmr3" not in policy
+        assert "accept_self_signed_certs" not in policy
+
     def test_bootchain_without_os_image_hash_raises(self, bootchain):
         """Test that providing bootchain without os_image_hash raises ValueError."""
         with pytest.raises(ValueError, match="must be provided together"):

--- a/python/tests/test_policy.py
+++ b/python/tests/test_policy.py
@@ -70,6 +70,22 @@ class TestDstackTdxPolicy:
         with pytest.raises(ValueError, match="must be provided together"):
             dstack_tdx_policy(os_image_hash=os_image_hash)
 
+    def test_self_signed_without_rtmr3_raises(self):
+        """Self-signed mode must be pinned to one measured RTMR3 instance."""
+        with pytest.raises(ValueError, match="requires expected_rtmr3"):
+            dstack_tdx_policy(accept_self_signed_certs=True)
+
+    def test_self_signed_with_rtmr3_is_included(self):
+        """Self-signed mode is emitted only with the required RTMR3 pin."""
+        expected_rtmr3 = "11" * 48
+        policy = dstack_tdx_policy(
+            expected_rtmr3=expected_rtmr3,
+            accept_self_signed_certs=True,
+        )
+
+        assert policy["accept_self_signed_certs"] is True
+        assert policy["expected_rtmr3"] == expected_rtmr3
+
     def test_dstack_tdx_policy_app_compose_overrides(self):
         """Test that app_compose overrides work correctly."""
         policy = dstack_tdx_policy(

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atlas-wasm"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -75,6 +75,10 @@ const response = await fetch("/v1/chat/completions", {
 
 console.log(response.status);
 console.log(response.attestation); // { trusted: true, teeType: "Tdx", ... }
+
+// Release this fetch instance's pooled connection when it is no longer needed.
+// A later request through the same function reconnects and re-attests.
+fetch.close();
 ```
 
 ### Low-level: `AtlsHttp`

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concrete-security/atlas-wasm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "aTLS client for browsers - attested fetch for Trusted Execution Environments",
   "repository": {
     "type": "git",
@@ -17,5 +17,8 @@
     "fetch",
     "confidential-computing"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "test": "node --test tests/atls-fetch.test.mjs tests/version.test.mjs"
+  }
 }

--- a/wasm/proxy/tests/integration.rs
+++ b/wasm/proxy/tests/integration.rs
@@ -14,10 +14,7 @@ async fn get_available_port() -> u16 {
 
 /// Spawn the proxy server with given configuration.
 /// Returns the proxy listen address and a shutdown sender.
-async fn spawn_proxy(
-    target: &str,
-    allowlist: &str,
-) -> (String, tokio::task::JoinHandle<()>) {
+async fn spawn_proxy(target: &str, allowlist: &str) -> (String, tokio::task::JoinHandle<()>) {
     let proxy_port = get_available_port().await;
     let listen_addr = format!("127.0.0.1:{}", proxy_port);
     let listen_addr_clone = listen_addr.clone();
@@ -228,7 +225,8 @@ async fn test_websocket_target_from_query_param() {
 
     // Connect with target pointing to echo_addr2 via query param
     // URL encode the target to handle the colon properly
-    let encoded_target: String = url::form_urlencoded::byte_serialize(echo_addr2.as_bytes()).collect();
+    let encoded_target: String =
+        url::form_urlencoded::byte_serialize(echo_addr2.as_bytes()).collect();
     let url_with_target = format!("{}/tunnel?target={}", proxy_url, encoded_target);
     let (mut ws_stream, _) = connect_async(&url_with_target)
         .await

--- a/wasm/src/atls-fetch.d.ts
+++ b/wasm/src/atls-fetch.d.ts
@@ -17,7 +17,11 @@ export interface AtlsResponse extends Response {
   readonly attestation: AttestationResult;
 }
 
-export type AtlsFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<AtlsResponse>;
+export interface AtlsFetch {
+  (input: RequestInfo | URL, init?: RequestInit): Promise<AtlsResponse>;
+  /** Close this fetch instance's pooled connection. The next request reconnects. */
+  close(): void;
+}
 
 export function createAtlsFetch(options: AtlsFetchOptions): AtlsFetch;
 

--- a/wasm/src/atls-fetch.d.ts
+++ b/wasm/src/atls-fetch.d.ts
@@ -7,6 +7,7 @@ export interface AttestationResult {
 export interface AtlsFetchOptions {
   proxyUrl: string;
   targetHost: string;
+  policy: Record<string, unknown>;
   serverName?: string;
   defaultHeaders?: Record<string, string>;
   onAttestation?: (attestation: AttestationResult) => void;
@@ -21,4 +22,3 @@ export type AtlsFetch = (input: RequestInfo | URL, init?: RequestInit) => Promis
 export function createAtlsFetch(options: AtlsFetchOptions): AtlsFetch;
 
 export { AttestedStream } from "./atls_wasm.js";
-

--- a/wasm/src/atls-fetch.js
+++ b/wasm/src/atls-fetch.js
@@ -66,11 +66,14 @@ async function ensureWasm() {
 // ============================================================================
 
 /**
- * Connection cache keyed by (wsUrl, serverName).
- * Each entry holds an AtlsHttp instance that can be reused.
+ * Connection cache keyed by (fetch instance, wsUrl, serverName).
+ * Each entry holds an AtlsHttp instance that can be reused. The fetch instance
+ * namespace prevents a connection attested under one policy from being reused by
+ * a different policy.
  * @type {Map<string, AtlsHttp>}
  */
 const connectionCache = new Map();
+let nextConnectionPoolId = 0;
 
 /**
  * Close all cached connections.
@@ -143,8 +146,9 @@ function buildProxyUrl(base, target) {
  * Create a fetch-compatible function for attested TLS connections.
  *
  * Connections are automatically pooled and reused for subsequent requests
- * to the same target. The `onAttestation` callback is called only once
- * when a new connection is established (not on reused connections).
+ * through the returned fetch function to the same target. The `onAttestation`
+ * callback is called only once when a new connection is established (not on
+ * reused connections).
  *
  * @param {Object} options
  * @param {string} options.proxyUrl - WebSocket proxy URL (e.g., "ws://127.0.0.1:9000")
@@ -173,9 +177,10 @@ export function createAtlsFetch(options) {
     : normalizedTarget;
   const wsUrl = buildProxyUrl(proxyUrl, normalizedTarget);
   const base = new URL(`https://${normalizedTarget}`);
+  const poolId = nextConnectionPoolId++;
 
-  // Cache key for this connection target
-  const cacheKey = `${wsUrl}|${sni}`;
+  // Cache key for this configured fetch instance and connection target.
+  const cacheKey = `${poolId}|${wsUrl}|${sni}`;
 
   return async function atlsFetch(input, init = {}) {
     await ensureWasm();

--- a/wasm/src/atls-fetch.js
+++ b/wasm/src/atls-fetch.js
@@ -75,19 +75,26 @@ async function ensureWasm() {
 const connectionCache = new Map();
 let nextConnectionPoolId = 0;
 
+function closeCachedConnection(cacheKey) {
+  const http = connectionCache.get(cacheKey);
+  connectionCache.delete(cacheKey);
+  if (!http) return;
+
+  try {
+    http.close();
+  } catch (e) {
+    // Ignore errors during cleanup
+  }
+}
+
 /**
  * Close all cached connections.
  * Call this when you want to clean up resources.
  */
 export function closeAllConnections() {
-  for (const http of connectionCache.values()) {
-    try {
-      http.close();
-    } catch (e) {
-      // Ignore errors during cleanup
-    }
+  for (const cacheKey of [...connectionCache.keys()]) {
+    closeCachedConnection(cacheKey);
   }
-  connectionCache.clear();
 }
 
 /**
@@ -157,7 +164,10 @@ function buildProxyUrl(base, target) {
  * @param {string} [options.serverName] - TLS server name (defaults to hostname from targetHost)
  * @param {Object} [options.defaultHeaders] - Default headers to include in all requests
  * @param {Function} [options.onAttestation] - Callback when attestation is received (only on new connections)
- * @returns {Function} A fetch-compatible async function
+ * The returned function has a `close()` method that releases only its pooled
+ * connection. A later request reconnects and re-attests.
+ *
+ * @returns {Function & {close: Function}} A fetch-compatible async function
  */
 export function createAtlsFetch(options) {
   const { proxyUrl, targetHost, serverName, defaultHeaders, onAttestation, policy } = options;
@@ -182,7 +192,7 @@ export function createAtlsFetch(options) {
   // Cache key for this configured fetch instance and connection target.
   const cacheKey = `${poolId}|${wsUrl}|${sni}`;
 
-  return async function atlsFetch(input, init = {}) {
+  async function atlsFetch(input, init = {}) {
     await ensureWasm();
 
     // Try to reuse an existing connection
@@ -196,12 +206,7 @@ export function createAtlsFetch(options) {
       // Need to create a new connection
       // First, clean up any stale connection
       if (http) {
-        try {
-          http.close();
-        } catch (e) {
-          // Ignore cleanup errors
-        }
-        connectionCache.delete(cacheKey);
+        closeCachedConnection(cacheKey);
       }
 
       // Connect and perform aTLS handshake with policy
@@ -218,8 +223,7 @@ export function createAtlsFetch(options) {
         } catch (e) {
           console.error("[atls-fetch] onAttestation callback failed:", e);
           // Clean up the connection on attestation callback failure
-          connectionCache.delete(cacheKey);
-          try { http.close(); } catch (_) {}
+          closeCachedConnection(cacheKey);
           throw e;
         }
       }
@@ -265,8 +269,7 @@ export function createAtlsFetch(options) {
       );
     } catch (e) {
       // On request failure, remove the connection from cache
-      connectionCache.delete(cacheKey);
-      try { http.close(); } catch (_) {}
+      closeCachedConnection(cacheKey);
       throw e;
     }
 
@@ -292,7 +295,10 @@ export function createAtlsFetch(options) {
     });
 
     return response;
-  };
+  }
+
+  atlsFetch.close = () => closeCachedConnection(cacheKey);
+  return atlsFetch;
 }
 
 // Re-export for advanced usage

--- a/wasm/src/hyper_io.rs
+++ b/wasm/src/hyper_io.rs
@@ -44,7 +44,8 @@ impl<T: AsyncRead> Read for HyperIo<T> {
         }
 
         // SAFETY: We just initialized the buffer
-        let initialized = unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut u8, len) };
+        let initialized =
+            unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut u8, len) };
 
         match self.project().inner.poll_read(cx, initialized) {
             Poll::Ready(Ok(n)) => {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -11,13 +11,15 @@
 mod hyper_io;
 
 use async_io_stream::IoStream;
+use atlas_rs::{
+    atls_connect, dstack::merge_with_default_app_compose, AsyncWriteExt, Policy, TlsStream,
+};
 use bytes::Bytes;
 use futures::io::{ReadHalf, WriteHalf};
 use futures::AsyncReadExt;
 use http_body_util::{BodyExt, Full};
 use hyper::client::conn::http1;
 use hyper::Request;
-use atlas_rs::{dstack::merge_with_default_app_compose, atls_connect, AsyncWriteExt, Policy, TlsStream};
 use serde::Serialize;
 use std::{cell::RefCell, rc::Rc};
 use wasm_bindgen::prelude::*;
@@ -56,28 +58,30 @@ fn create_readable_stream(reader: ReadHalf<TlsStream<WsIo>>) -> web_sys::Readabl
     let underlying_source = Object::new();
 
     let reader_clone = reader.clone();
-    let pull = Closure::wrap(Box::new(move |controller: ReadableStreamDefaultController| {
-        let reader = reader_clone.clone();
-        let promise = wasm_bindgen_futures::future_to_promise(async move {
-            let mut buf = vec![0u8; 16 * 1024];
-            let mut reader_ref = reader.borrow_mut();
-            match reader_ref.read(&mut buf).await {
-                Ok(0) => {
-                    controller.close().ok();
+    let pull = Closure::wrap(
+        Box::new(move |controller: ReadableStreamDefaultController| {
+            let reader = reader_clone.clone();
+            let promise = wasm_bindgen_futures::future_to_promise(async move {
+                let mut buf = vec![0u8; 16 * 1024];
+                let mut reader_ref = reader.borrow_mut();
+                match reader_ref.read(&mut buf).await {
+                    Ok(0) => {
+                        controller.close().ok();
+                    }
+                    Ok(n) => {
+                        let chunk = Uint8Array::from(&buf[..n]);
+                        controller.enqueue_with_chunk(&chunk.into()).ok();
+                    }
+                    Err(e) => {
+                        let error = JsValue::from_str(&e.to_string());
+                        controller.error_with_e(&error);
+                    }
                 }
-                Ok(n) => {
-                    let chunk = Uint8Array::from(&buf[..n]);
-                    controller.enqueue_with_chunk(&chunk.into()).ok();
-                }
-                Err(e) => {
-                    let error = JsValue::from_str(&e.to_string());
-                    controller.error_with_e(&error);
-                }
-            }
-            Ok(JsValue::UNDEFINED)
-        });
-        promise
-    }) as Box<dyn FnMut(ReadableStreamDefaultController) -> Promise>);
+                Ok(JsValue::UNDEFINED)
+            });
+            promise
+        }) as Box<dyn FnMut(ReadableStreamDefaultController) -> Promise>,
+    );
 
     Reflect::set(&underlying_source, &"pull".into(), pull.as_ref()).unwrap();
     pull.forget();
@@ -419,7 +423,11 @@ impl AtlsHttp {
         let headers_obj = Object::new();
         for (name, value) in response.headers() {
             let value_str = value.to_str().unwrap_or("");
-            Reflect::set(&headers_obj, &name.as_str().into(), &JsValue::from_str(value_str))?;
+            Reflect::set(
+                &headers_obj,
+                &name.as_str().into(),
+                &JsValue::from_str(value_str),
+            )?;
         }
 
         // Create ReadableStream from hyper body
@@ -450,38 +458,40 @@ fn create_hyper_body_stream(body: hyper::body::Incoming) -> web_sys::ReadableStr
     let body = Rc::new(RefCell::new(Some(body)));
     let underlying_source = Object::new();
 
-    let pull = Closure::wrap(Box::new(move |controller: ReadableStreamDefaultController| {
-        let body = body.clone();
+    let pull = Closure::wrap(
+        Box::new(move |controller: ReadableStreamDefaultController| {
+            let body = body.clone();
 
-        wasm_bindgen_futures::future_to_promise(async move {
-            let mut body_opt = body.borrow_mut();
+            wasm_bindgen_futures::future_to_promise(async move {
+                let mut body_opt = body.borrow_mut();
 
-            if let Some(body_inner) = body_opt.as_mut() {
-                // Try to get the next frame from the body
-                match body_inner.frame().await {
-                    Some(Ok(frame)) => {
-                        if let Some(data) = frame.data_ref() {
-                            let arr = Uint8Array::from(data.as_ref());
-                            controller.enqueue_with_chunk(&arr.into()).ok();
+                if let Some(body_inner) = body_opt.as_mut() {
+                    // Try to get the next frame from the body
+                    match body_inner.frame().await {
+                        Some(Ok(frame)) => {
+                            if let Some(data) = frame.data_ref() {
+                                let arr = Uint8Array::from(data.as_ref());
+                                controller.enqueue_with_chunk(&arr.into()).ok();
+                            }
+                            // If it's a trailers frame, we ignore it
                         }
-                        // If it's a trailers frame, we ignore it
+                        Some(Err(e)) => {
+                            let error = JsValue::from_str(&format!("Body read error: {e}"));
+                            controller.error_with_e(&error);
+                        }
+                        None => {
+                            // Body complete
+                            controller.close().ok();
+                        }
                     }
-                    Some(Err(e)) => {
-                        let error = JsValue::from_str(&format!("Body read error: {e}"));
-                        controller.error_with_e(&error);
-                    }
-                    None => {
-                        // Body complete
-                        controller.close().ok();
-                    }
+                } else {
+                    controller.close().ok();
                 }
-            } else {
-                controller.close().ok();
-            }
 
-            Ok(JsValue::UNDEFINED)
-        })
-    }) as Box<dyn FnMut(ReadableStreamDefaultController) -> Promise>);
+                Ok(JsValue::UNDEFINED)
+            })
+        }) as Box<dyn FnMut(ReadableStreamDefaultController) -> Promise>,
+    );
 
     Reflect::set(&underlying_source, &"pull".into(), pull.as_ref()).unwrap();
     pull.forget();

--- a/wasm/tests/atls-fetch.test.mjs
+++ b/wasm/tests/atls-fetch.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+
+test("fetch factories isolate and release their pooled connections", async (t) => {
+  const fixtureDir = mkdtempSync(join(tmpdir(), "atlas-wasm-fetch-"));
+  t.after(() => rmSync(fixtureDir, { recursive: true, force: true }));
+
+  copyFileSync(
+    fileURLToPath(new URL("../src/atls-fetch.js", import.meta.url)),
+    join(fixtureDir, "atls-fetch.js")
+  );
+  writeFileSync(join(fixtureDir, "package.json"), '{"type":"module"}');
+  writeFileSync(
+    join(fixtureDir, "atlas_wasm.js"),
+    [
+      "export default async function init() {}",
+      "export class AttestedStream {}",
+      "export function mergeWithDefaultAppCompose(value) { return value; }",
+      "export class AtlsHttp {",
+      "  static instances = [];",
+      "  static async connect() {",
+      "    const instance = new AtlsHttp();",
+      "    AtlsHttp.instances.push(instance);",
+      "    return instance;",
+      "  }",
+      "  constructor() { this.closed = false; }",
+      "  isReady() { return !this.closed; }",
+      '  attestation() { return { trusted: true, teeType: "Tdx", tcbStatus: "UpToDate" }; }',
+      '  async fetch() { return { status: 200, statusText: "OK", headers: {}, body: null }; }',
+      "  close() { this.closed = true; }",
+      "}",
+      ""
+    ].join("\n")
+  );
+
+  const {
+    AtlsHttp,
+    closeAllConnections,
+    createAtlsFetch,
+    getConnectionPoolStats
+  } = await import(pathToFileURL(join(fixtureDir, "atls-fetch.js")).href);
+
+  const options = {
+    proxyUrl: "ws://127.0.0.1:9000",
+    targetHost: "example.test:443",
+    policy: { type: "dstack_tdx" }
+  };
+  const first = createAtlsFetch(options);
+  const second = createAtlsFetch(options);
+
+  await first("https://example.test/one");
+  await first("https://example.test/two");
+  assert.equal(AtlsHttp.instances.length, 1, "one factory reuses its connection");
+
+  await second("https://example.test/three");
+  assert.equal(getConnectionPoolStats().total, 2, "factories remain policy-isolated");
+
+  first.close();
+  assert.equal(getConnectionPoolStats().total, 1);
+  assert.equal(AtlsHttp.instances[0].closed, true);
+  assert.equal(AtlsHttp.instances[1].closed, false);
+
+  first.close();
+  assert.equal(getConnectionPoolStats().total, 1, "close is idempotent");
+
+  await first("https://example.test/reconnected");
+  assert.equal(AtlsHttp.instances.length, 3, "a closed factory reconnects");
+  assert.equal(getConnectionPoolStats().total, 2);
+
+  second.close();
+  assert.equal(getConnectionPoolStats().total, 1);
+  first.close();
+  assert.equal(getConnectionPoolStats().total, 0);
+
+  closeAllConnections();
+});

--- a/wasm/tests/version.test.mjs
+++ b/wasm/tests/version.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("WASM crate and npm package versions match", () => {
+  const packageJson = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8")
+  );
+  const cargoToml = readFileSync(new URL("../Cargo.toml", import.meta.url), "utf8");
+  const crateVersion = cargoToml.match(
+    /^\s*version\s*=\s*"([^"]+)"\s*$/m
+  )?.[1];
+
+  assert.ok(crateVersion, "Cargo.toml package version must be present");
+  assert.equal(packageJson.version, crateVersion);
+});


### PR DESCRIPTION
## What & why

Two coupled changes that make the frozen-self-signed-cert direction safe to enforce, released together as **0.3.0**. Came out of a 3-reviewer security audit of PR #38 (`accept-self-signed-certs`), which found the feature sound in mechanism but unsafe in its default — plus a pre-existing critical gap in the event-log trust chain.

### 1. `fix(core)` — authenticate RTMR3 event-log payloads (security, independent)

`replay_rtmrs()` replays each event's `digest` verbatim and never rebinds it to `(event_type, event, event_payload)`, yet the verifier reads `event_payload` to decide the cert / compose-hash / os-image-hash. An attacker serving the event log could keep the genuine digests (so RTMR replay still matches the quote) while rewriting `event_payload` to forge those values — confirmed with a working PoC (honest vs forged event logs replay to a byte-identical RTMR3).

Fix: recompute each RTMR3 (`imr==3`) event's digest as `sha384(event_type.to_le_bytes() ‖ b":" ‖ event ‖ b":" ‖ event_payload)` and reject mismatches before any payload is trusted. This binds `payload → digest`; RTMR replay already binds `digest → quote`. Mirrors dstack `cc-eventlog` `TdxEventLog::validate` (imr==3 only). The derivation is verified against a real dstack event log (little-endian reproduces all genuine imr==3 digests). **This is a pre-existing vulnerability independent of the self-signed feature; it can be reviewed/landed on its own (first commit).**

### 2. `feat(core)` — safe self-signed acceptance + RTMR3 pinning

`accept_self_signed_certs` (reworked from #38):
- **Defaults to `false`** — standard CA + hostname validation applies unless a caller explicitly opts in. (In #38 it defaulted `true`, which silently stripped CA + hostname + expiry from every existing policy on upgrade.)
- When `true`, skips CA chain, hostname/SAN, **and** expiry (docs say so), but still verifies the handshake signature (peer must hold the key).
- `validate()` rejects `accept_self_signed_certs` + `disable_runtime_verification` (pins neither identity nor measurements). `dev()` stays CA-validating.
- `supported_algs` is read from the installed `CryptoProvider` (matching `ClientConfig::builder`), not a `target_arch` hardcode.

`expected_rtmr3`: optional 96-hex pin of the full RTMR3 register, checked against the DCAP-verified report. Provides the per-instance binding the dropped hostname check no longer gives. Absent by default (backward-compatible).

Both fields are exposed on the Node (`.d.ts`) and Python policy surfaces.

## Breaking changes (hence 0.3.0)
- `tls_handshake` gains a required `accept_self_signed_certs: bool` argument.
- `DstackTdxPolicy` / `DstackTDXVerifierConfig` gain fields (constructors using `..Default::default()` are unaffected).

## Verification
`cargo test`: 35 lib + 6 integration (12 dead-enclave live tests `#[ignore]`) + 11 doctests, all green. `cargo clippy --lib` clean (2 pre-existing warnings unrelated). Compiles on `wasm32-unknown-unknown`. New tests include a non-circular real-vector digest test and the forged-payload rejection.

## Deferred (noted, not done here)
- Flag rename to something like `skip_certificate_validation` (kept `accept_self_signed_certs` to avoid a 3-repo ripple; docs corrected instead).
- `#[non_exhaustive]` on `DstackTdxPolicy` (would break external `..Default` literals; revisit post-0.3.0).

Supersedes the intent of #38 (default flipped, docs corrected, provider-algs fixed).
