### PR TITLE
fix(security): resolve CodeQL alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test-core:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -24,6 +24,9 @@ on:
 env:
   CRATE_BASE_DIR: ${{ github.workspace }}/core
 
+permissions:
+  contents: read
+
 jobs:
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -25,6 +25,9 @@ env:
   MACOSX_DEPLOYMENT_TARGET: '10.13'
   CARGO_INCREMENTAL: 0
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent guidance
+
+Read `CLAUDE.md` for repository commands, architecture, and security invariants.
+
+## Git conventions
+
+Use Conventional Commit subjects and matching PR titles: `<type>(<scope>): <description>`. Omit the scope only when no clear subsystem applies, and confirm the type and scope against recent repository history before publishing.

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -518,8 +518,7 @@ impl AtlsVerifier for DstackTDXVerifier {
         debug!("Starting DStack TDX verification for {}", hostname);
 
         // 1. Generate nonce and get quote via HTTP POST to /tdx_quote
-        let mut nonce = [0u8; 32];
-        rand::Rng::fill(&mut rand::thread_rng(), &mut nonce);
+        let nonce: [u8; 32] = rand::random();
 
         // Get quote via HTTP POST to /tdx_quote
         let quote_response = get_quote_over_http(stream, &nonce, hostname).await?;

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -266,8 +266,7 @@ mod integration {
     #[tokio::test]
     #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
     async fn test_grace_period_outofdate_paths() {
-        let mut nonce = [0u8; 32];
-        rand::Rng::fill(&mut rand::thread_rng(), &mut nonce);
+        let nonce: [u8; 32] = rand::random();
 
         let quote_response = get_quote_over_http(&nonce, TEST_HOST)
             .await


### PR DESCRIPTION
## Summary

- Set workflow-level `GITHUB_TOKEN` permissions to `contents: read` for CI and the unprivileged build/package jobs.
- Preserve the existing job-level `contents: write` and `id-token: write` grants required by release jobs.
- Initialize both 32-byte attestation nonces directly from `rand::random()`, removing the misleading zero-filled intermediate state flagged by CodeQL.
- Document the repository's Conventional Commit and matching PR-title convention in `AGENTS.md`, with `CLAUDE.md` as the detailed project guide.

## Why

CodeQL reported seven workflows/jobs without explicit token permissions and two hard-coded cryptographic values. The repository currently defaults workflow tokens to read-only, but encoding least privilege in each workflow prevents configuration drift. The nonce findings were false positives: the zero-filled arrays were completely overwritten by `ThreadRng` before use. Direct initialization keeps the same CSPRNG and fail-before-use behavior while making that invariant explicit.

## Impact

CI and release behavior is preserved. Unprivileged jobs are constrained to repository read access, privileged release jobs retain their explicit permissions, and the attestation nonce remains a fresh 32-byte cryptographically secure random value.

## Validation

- `make test`
- `CC=/opt/homebrew/opt/llvm/bin/clang AR=/opt/homebrew/opt/llvm/bin/llvm-ar make test-wasm`
- `cargo clippy --workspace --exclude atlas-wasm` (passes with two pre-existing warnings)
- Workflow YAML parsing and effective-permission inspection
- `git diff --check`
- Confirmed the old CodeQL nonce patterns are absent

`cargo fmt --all --check` still reports existing repository-wide formatting drift; it fails identically on the unmodified base revision.