### PR TITLE
fix(security): disable TLS session resumption and require EMS

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,7 @@ The following properties must hold:
 - the TLS server name and certificate chain are verified before the connection is returned;
 - TDX evidence is cryptographically verified and its TCB status is explicitly allowed by policy;
 - the attested certificate and EKM bind the evidence to the current TLS connection and prevent replay across sessions;
+- TLS session resumption and 0-RTT are never used: every connection performs a full handshake followed by fresh attestation verification before it is returned;
 - when runtime verification is enabled, expected bootchain measurements, OS image, application composition, and replayed runtime measurements must all match;
 - verification failures are fail-closed and never return a usable connection;
 - language bindings preserve the core verification result and do not silently weaken policy;

--- a/core/src/connect.rs
+++ b/core/src/connect.rs
@@ -9,6 +9,7 @@ use crate::error::AtlsVerificationError;
 use crate::policy::Policy;
 use crate::verifier::{AsyncByteStream, Report};
 use crate::AtlsVerifier;
+use rustls::client::Resumption;
 use rustls::pki_types::ServerName;
 use rustls::{ClientConfig, RootCertStore};
 use std::sync::Arc;
@@ -55,6 +56,14 @@ where
     let mut config = ClientConfig::builder()
         .with_root_certificates(root_store)
         .with_no_client_auth();
+
+    // Attestation evidence is bound to this connection's EKM, so every
+    // connection must run a fresh verification: never store or offer session
+    // tickets, so a session can't resume past attestation.
+    config.resumption = Resumption::disabled();
+    // EKM is only transcript-bound on TLS 1.2 with extended master secret
+    // (RFC 7627); reject TLS 1.2 peers that don't support it.
+    config.require_ems = true;
 
     if let Some(protocols) = alpn {
         config.alpn_protocols = protocols.into_iter().map(|s| s.into_bytes()).collect();


### PR DESCRIPTION
## Summary

Response to the reported aTLS session-resumption attestation-bypass advisory. Assessment: **not exploitable in Atlas** — two independent barriers:

1. **Resumption could never occur.** The rustls client session store lives inside the `ClientConfig`, which `tls_handshake` builds fresh for every connection and never reuses — a `NewSessionTicket` is written into a store no future connection ever reads. The next ClientHello offers no PSK/ticket, and a server cannot resume unilaterally.
2. **Attestation gates every connection.** `atls_connect` returns the stream only after verification succeeds, and evidence must satisfy `report_data == SHA512(fresh nonce || this connection's EKM)`, so there is no "attested session" state a resumed connection could inherit.

This PR turns the accidental no-resumption property into a declared invariant (advisory workaround Option 1):

- `config.resumption = Resumption::disabled()` — no session tickets stored or offered; shared handshake path covers native and WASM
- `config.require_ems = true` — reject TLS 1.2 peers without extended master secret (RFC 7627), keeping EKM transcript-bound
- `SECURITY.md` — document the no-resumption / no-0-RTT invariant

Behavior change: TLS 1.2 servers lacking EMS are now rejected (universally supported since 2015; TLS 1.3 unaffected).

## Verification

- `make test` passes
- `make test-wasm` passes
- `cargo clippy --workspace --exclude atlas-wasm` clean (2 pre-existing warnings in untouched files)
- `cargo fmt` — touched files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)