### PR TITLE
feat: transparent client-side re-attestation of established connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ make build-python
 
 ## Repo map (look here first)
 
-- `core/src/connect.rs`: high-level entrypoint `atls_connect(...)`.
+- `core/src/connect.rs`: high-level entrypoints `atls_connect(...)`, `atls_connect_with_reattester(...)`.
+- `core/src/reattest.rs`: `Reattester` for periodic in-band re-attestation (policy: `reattestation_interval_secs`, default 300, 0 disables).
 - `core/src/verifier.rs`: verifier traits and runtime dispatch enums.
 - `core/src/policy.rs`: serde-tagged `Policy` enum.
 - `core/src/dstack/`: Intel TDX verifier implementation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
+ "wasm-bindgen",
  "webpki-roots 0.26.11",
 ]
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,6 +54,8 @@ The following properties must hold:
 - TDX evidence is cryptographically verified and its TCB status is explicitly allowed by policy;
 - the attested certificate and EKM bind the evidence to the current TLS connection and prevent replay across sessions;
 - when runtime verification is enabled, expected bootchain measurements, OS image, application composition, and replayed runtime measurements must all match;
+- unless re-attestation is explicitly disabled (`reattestation_interval_secs: 0`), no request is dispatched by a binding's HTTP client on a connection whose attestation evidence is older than the configured interval (default 300 seconds): the connection is transparently re-attested in-band — the full verification pipeline over the live session, with a fresh nonce bound to the same session EKM — or replaced by a freshly attested connection;
+- a failed re-attestation is fail-closed: the evidence age is never refreshed, the connection is torn down, and it is never reused;
 - verification failures are fail-closed and never return a usable connection;
 - language bindings preserve the core verification result and do not silently weaken policy;
 - the proxy rejects every target that is not exactly present in its configured allowlist; and
@@ -70,5 +72,11 @@ The following are not vulnerabilities by themselves:
 - social engineering, physical attacks, volumetric denial of service, and documentation-only issues without security impact.
 
 A path that activates relaxed verification without explicit caller intent, or that bypasses checks which remain promised in relaxed mode, is in scope. Intel TDX through Dstack is the current production verifier; planned TEE platforms are not security claims until implemented and documented.
+
+Known limitations of periodic re-attestation:
+
+- staleness is checked lazily at message boundaries, so a single response that streams for longer than the interval is not interrupted mid-flight; the connection is re-verified at the next boundary;
+- the residual window between re-attestations remains: workload or platform state changes are detected no faster than the configured interval, and only insofar as they are reflected in measured state (quotes cannot reveal unmeasured runtime memory modification);
+- the low-level raw-stream APIs (`atls_connect` in Rust, `AttestedStream` in WASM) leave re-attestation to the caller, since the library does not know the application's protocol framing; the Rust `Reattester` API supports doing it manually.
 
 Only test systems you own or have explicit permission to test. Do not disrupt services, access other users' data, or test Concrete-operated production infrastructure without prior written authorization.

--- a/core/ARCHITECTURE.md
+++ b/core/ARCHITECTURE.md
@@ -146,19 +146,43 @@ When `atls_connect()` is called:
    - Verify measurements (bootchain, app config, OS image)
 5. **Return** - Return `(TlsStream, Report)` for continued communication
 
+### Re-attestation Flow
+
+`atls_connect_with_reattester()` additionally returns a `Reattester`
+(`reattest.rs`) that retains the verifier, session peer certificate, and
+session EKM. At safe message boundaries, callers check `is_due()` (evidence
+age vs. the policy's `reattestation_interval_secs`; 0 disables) and call
+`reattest(&mut stream)`, which re-runs the full verify pipeline with a fresh
+nonce bound to the same session EKM. For transports that own the stream (e.g.
+hyper in the wasm binding), `begin()`/`finish()` split the exchange: the
+caller sends the `/tdx_quote` request itself and hands the response body back
+for appraisal.
+
+The only difference from initial verification is the certificate/event-log
+check (`CertEventMatch` in `dstack/verifier.rs`): initial handshakes require
+the *latest* `New TLS Certificate` event to match (`Latest`), while
+re-attestation accepts *any* matching event (`Any`) because a mid-session
+certificate rotation on the attester appends a new event to the append-only
+log while the session certificate stays valid. The log is
+integrity-protected by RTMR replay in both modes. Failures wrap in
+`AtlsVerificationError::Reattestation` and are fail-closed: the evidence age
+is not refreshed and the connection must not be used further.
+
 ## Module Structure
 
 ```
 core/src/
 ├── lib.rs              # Public API re-exports
-├── connect.rs          # atls_connect(), tls_handshake()
+├── connect.rs          # atls_connect(), atls_connect_with_reattester(), tls_handshake()
+├── reattest.rs         # Reattester, ReattestRequest (periodic re-attestation)
 ├── verifier.rs         # AtlsVerifier trait, Report/Verifier enums
 ├── policy.rs           # Policy enum
 ├── error.rs            # AtlsVerificationError
+├── time.rs             # Platform time helper (now_secs)
 │
 ├── dstack/             # DStack TDX implementation
 │   ├── mod.rs          # Re-exports
-│   ├── verifier.rs     # DstackTDXVerifier (AtlsVerifier impl)
+│   ├── verifier.rs     # DstackTDXVerifier (AtlsVerifier impl), CertEventMatch
 │   ├── config.rs       # DstackTDXVerifierConfig, Builder
 │   ├── policy.rs       # DstackTdxPolicy (IntoVerifier impl)
 │   └── compose_hash.rs # Deterministic app config hashing

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,6 +49,7 @@ futures-rustls = { version = "0.26", default-features = false, features = ["ring
 # Ring needs explicit WASM feature for wasm32 targets
 ring = { version = "0.17", features = ["wasm32_unknown_unknown_js"] }
 js-sys = "0.3"
+wasm-bindgen = "0.2"
 console_log = "1"
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,5 +52,5 @@ js-sys = "0.3"
 console_log = "1"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "net", "io-util"] }
+tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "net", "io-util", "time"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }

--- a/core/README.md
+++ b/core/README.md
@@ -185,12 +185,14 @@ Policy fields vary by verifier implementation. The `Policy` enum wraps implement
 | `app_compose` | Expected application configuration | Yes (unless disabled) |
 | `allowed_tcb_status` | Acceptable TCB statuses (e.g., `["UpToDate"]`) | Yes |
 | `grace_period` | Grace period (seconds) for `OutOfDate` TCB status. `0` means no grace window. | No |
+| `reattestation_interval_secs` | Max age (seconds) of attestation evidence before transparent re-attestation. Default: `300`. `0` disables re-attestation; non-zero values below `30` are rejected. | No |
 | `disable_runtime_verification` | Skip runtime checks (default: false) | No |
 | `pccs_url` | Intel PCCS URL (defaults to Phala's) | No |
 | `cache_collateral` | Cache Intel collateral (default: false) | No |
 
 Time-based TCB checks:
 - `grace_period` applies only when the TCB status is `OutOfDate` and requires `OutOfDate` in `allowed_tcb_status`. A value of `0` means no grace window.
+- `reattestation_interval_secs` bounds how old attestation evidence may be when the connection is used; see [Periodic Re-attestation](#periodic-re-attestation).
 
 ```rust
 use atlas_rs::{Policy, DstackTdxPolicy, ExpectedBootchain};
@@ -275,6 +277,45 @@ Since the EKM is derived from the TLS session's master secret (unique per sessio
 - **Standards-based** - Uses RFC 9266 channel binding for TLS 1.3
 - **Defense-in-depth** - Protects against key compromise scenarios
 
+### Periodic Re-attestation
+
+A single attestation only proves the workload state at connect time. To bound
+the window in which an attacker could modify workload state unnoticed, Atlas
+re-attests established connections during their lifetime, controlled by
+`reattestation_interval_secs` (default 300 seconds; `0` disables it).
+
+**Semantics:** the interval is the maximum age of attestation evidence *at the
+moment the connection is used*. There are no background timers: staleness is
+checked lazily at safe message boundaries (no request/response in flight), so
+a connection that sat idle for an hour is re-verified right before its next
+request. A single long-running response (e.g. a streaming completion) cannot
+be interrupted mid-flight; it is re-checked at the next boundary.
+
+**How it works:** re-attestation repeats the full verification pipeline —
+`/tdx_quote` exchange, DCAP verification, RTMR replay, bootchain, app compose,
+and OS image checks — with a **fresh nonce** bound to the **same session EKM**
+(`report_data = SHA512(nonce || session_ekm)`). The fresh nonce guarantees
+evidence freshness; the EKM (a secret that never leaves the TLS endpoints)
+binds the fresh evidence to this specific live session. Each cycle therefore
+carries the same security weight as the initial attestation. The one
+difference: the session certificate may match *any* `New TLS Certificate`
+event in the log rather than only the latest, because a mid-session server
+certificate rotation appends a new event while the session certificate stays
+valid (the log is append-only and integrity-protected by RTMR replay).
+
+**Failure is fail-closed:** a failed re-attestation returns
+`AtlsVerificationError::Reattestation`, the evidence age is not refreshed, and
+the connection must not be used further. Language bindings tear the connection
+down; pooled clients transparently reconnect, which performs a full fresh
+attestation.
+
+**Rust API:** use `atls_connect_with_reattester` to obtain a `Reattester`
+handle alongside the stream, then call `reattester.is_due()` /
+`reattester.reattest(&mut stream)` at your protocol's message boundaries. For
+transports that own the stream (e.g. an HTTP client), use
+`reattester.begin()` to get the `/tdx_quote` request parameters and
+`reattester.finish(&request, &response_body)` to appraise the response.
+
 ## Protocol Specification
 
 ### Step 1: TLS Handshake
@@ -330,6 +371,15 @@ Server responds:
 3. Recompute RTMR3 by replaying every event log entry in order and ensure the final digest matches the quote
 4. During that replay, locate the TLS key binding event (contains the certificate pubkey hash) to prove the attested workload owns the negotiated TLS key
 5. Verify bootchain (MRTD, RTMR0-2), app compose hash, and OS image hash against policy
+
+### Step 4: Re-attestation (periodic)
+
+While the connection stays open, the client repeats the Step 2 exchange and
+Step 3 verification over the live session with a fresh nonce whenever the
+evidence age exceeds `reattestation_interval_secs` at a message boundary. The
+session certificate check accepts any matching `New TLS Certificate` event
+(not only the latest) to tolerate mid-session certificate rotation on the
+attester.
 
 ## TCB Status Values
 

--- a/core/src/connect.rs
+++ b/core/src/connect.rs
@@ -7,6 +7,7 @@ use log::debug;
 
 use crate::error::AtlsVerificationError;
 use crate::policy::Policy;
+use crate::reattest::Reattester;
 use crate::verifier::{AsyncByteStream, Report};
 use crate::AtlsVerifier;
 use rustls::pki_types::ServerName;
@@ -140,6 +141,51 @@ pub async fn atls_connect<S>(
 where
     S: AsyncByteStream + 'static,
 {
+    let (tls_stream, report, _reattester) =
+        atls_connect_with_reattester(stream, server_name, policy, alpn).await?;
+    Ok((tls_stream, report))
+}
+
+/// Establish a verified aTLS connection and return a re-attestation handle.
+///
+/// Identical to [`atls_connect`], but additionally returns a
+/// [`Reattester`] retaining the verifier, session peer certificate, and
+/// session EKM, so the connection can be transparently re-verified during
+/// its lifetime. See [`crate::reattest`] for usage and safety requirements.
+///
+/// The re-attestation interval comes from the policy
+/// (`reattestation_interval_secs`, default 300 seconds; 0 disables
+/// re-attestation, in which case [`Reattester::is_due`] is always false).
+///
+/// # Example
+///
+/// ```no_run
+/// use atlas_rs::{atls_connect_with_reattester, Policy, DstackTdxPolicy};
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let tcp = tokio::net::TcpStream::connect("tee.example.com:443").await?;
+/// let policy = Policy::DstackTdx(DstackTdxPolicy::dev());
+/// let (mut tls_stream, report, reattester) =
+///     atls_connect_with_reattester(tcp, "tee.example.com", policy, None).await?;
+///
+/// // ... use the connection ...
+///
+/// // Later, at a message boundary (no request/response in flight):
+/// if reattester.is_due() {
+///     let fresh_report = reattester.reattest(&mut tls_stream).await?;
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub async fn atls_connect_with_reattester<S>(
+    stream: S,
+    server_name: &str,
+    policy: Policy,
+    alpn: Option<Vec<String>>,
+) -> Result<(TlsStream<S>, Report, Reattester), AtlsVerificationError>
+where
+    S: AsyncByteStream + 'static,
+{
     // Initialize logging (idempotent, only runs once)
     crate::logging::init();
 
@@ -153,5 +199,7 @@ where
 
     debug!("Attestation verification successful");
 
-    Ok((tls_stream, report))
+    let reattester = Reattester::new(verifier, peer_cert, session_ekm, server_name.to_string());
+
+    Ok((tls_stream, report, reattester))
 }

--- a/core/src/connect.rs
+++ b/core/src/connect.rs
@@ -193,13 +193,23 @@ where
 
     debug!("Starting attestation verification");
     let verifier = policy.into_verifier()?;
+    // Anchor the evidence age at the moment verification starts (nonce
+    // issuance), not when it completes, so a slow exchange cannot overstate
+    // freshness.
+    let verified_at_millis = crate::time::mono_millis();
     let report = verifier
         .verify(&mut tls_stream, &peer_cert, &session_ekm, server_name)
         .await?;
 
     debug!("Attestation verification successful");
 
-    let reattester = Reattester::new(verifier, peer_cert, session_ekm, server_name.to_string());
+    let reattester = Reattester::new_at(
+        verifier,
+        peer_cert,
+        session_ekm,
+        server_name.to_string(),
+        verified_at_millis,
+    );
 
     Ok((tls_stream, report, reattester))
 }

--- a/core/src/dstack/config.rs
+++ b/core/src/dstack/config.rs
@@ -1,5 +1,6 @@
 //! Configuration types for DStack TDX verification.
 
+use crate::dstack::policy::DEFAULT_REATTESTATION_INTERVAL_SECS;
 use crate::tdx::ExpectedBootchain;
 
 /// Configuration for DstackTDXVerifier.
@@ -23,6 +24,13 @@ pub struct DstackTDXVerifierConfig {
     ///
     /// If set, OutOfDate platforms are only allowed within this window.
     pub grace_period: Option<u64>,
+
+    /// Maximum age (seconds) of attestation evidence before re-attestation.
+    ///
+    /// Re-attestation-aware clients re-run verification over the live
+    /// session when the evidence is older than this at a message boundary.
+    /// 0 disables re-attestation. Default: 300 (5 minutes).
+    pub reattestation_interval_secs: u64,
 
     /// Disable runtime verification (NOT RECOMMENDED).
     ///
@@ -59,6 +67,7 @@ impl Default for DstackTDXVerifierConfig {
             app_compose: None,
             allowed_tcb_status: vec!["UpToDate".to_string()],
             grace_period: None,
+            reattestation_interval_secs: DEFAULT_REATTESTATION_INTERVAL_SECS,
             disable_runtime_verification: false,
             expected_bootchain: None,
             os_image_hash: None,
@@ -139,6 +148,12 @@ impl DstackTDXVerifierBuilder {
     /// Set the grace period (seconds) for OutOfDate platforms.
     pub fn grace_period(mut self, seconds: u64) -> Self {
         self.config.grace_period = Some(seconds);
+        self
+    }
+
+    /// Set the re-attestation interval in seconds (0 disables re-attestation).
+    pub fn reattestation_interval_secs(mut self, seconds: u64) -> Self {
+        self.config.reattestation_interval_secs = seconds;
         self
     }
 

--- a/core/src/dstack/default_app_compose.rs
+++ b/core/src/dstack/default_app_compose.rs
@@ -354,7 +354,10 @@ mod tests {
         let full = merge_with_default_app_compose(&user_compose);
 
         // User values are preserved
-        assert_eq!(full["docker_compose_file"], "services:\n  app:\n    image: test");
+        assert_eq!(
+            full["docker_compose_file"],
+            "services:\n  app:\n    image: test"
+        );
         assert_eq!(full["allowed_envs"], json!(["MY_SECRET"]));
 
         // Defaults are filled in

--- a/core/src/dstack/mod.rs
+++ b/core/src/dstack/mod.rs
@@ -12,4 +12,5 @@ mod verifier;
 pub use config::{DstackTDXVerifierBuilder, DstackTDXVerifierConfig};
 pub use default_app_compose::{get_default_app_compose, merge_with_default_app_compose};
 pub use policy::DstackTdxPolicy;
+pub(crate) use verifier::CertEventMatch;
 pub use verifier::DstackTDXVerifier;

--- a/core/src/dstack/policy.rs
+++ b/core/src/dstack/policy.rs
@@ -9,8 +9,21 @@ use serde::{Deserialize, Serialize};
 /// Default PCCS URL for TDX collateral fetching.
 pub const DEFAULT_PCCS_URL: &str = "https://pccs.phala.network/tdx/certification/v4";
 
+/// Default re-attestation interval in seconds (5 minutes).
+pub const DEFAULT_REATTESTATION_INTERVAL_SECS: u64 = 300;
+
+/// Minimum allowed non-zero re-attestation interval in seconds.
+///
+/// Protects attesters from quote-generation storms caused by overly
+/// aggressive intervals. Use 0 to disable re-attestation entirely.
+pub const MIN_REATTESTATION_INTERVAL_SECS: u64 = 30;
+
 fn default_pccs_url() -> Option<String> {
     Some(DEFAULT_PCCS_URL.to_string())
+}
+
+fn default_reattestation_interval_secs() -> u64 {
+    DEFAULT_REATTESTATION_INTERVAL_SECS
 }
 
 fn default_allowed_tcb_status() -> Vec<String> {
@@ -43,6 +56,16 @@ pub struct DstackTdxPolicy {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub grace_period: Option<u64>,
 
+    /// Maximum age (seconds) of attestation evidence before the client
+    /// transparently re-attests the connection at the next message boundary.
+    ///
+    /// Re-attestation repeats the full verification (fresh nonce, same
+    /// session EKM) over the live connection. Defaults to 300 (5 minutes).
+    /// Set to 0 to disable re-attestation completely. Non-zero values below
+    /// 30 seconds are rejected.
+    #[serde(default = "default_reattestation_interval_secs")]
+    pub reattestation_interval_secs: u64,
+
     /// PCCS URL for collateral fetching.
     /// Defaults to `https://pccs.phala.network/tdx/certification/v4`.
     #[serde(default = "default_pccs_url", skip_serializing_if = "Option::is_none")]
@@ -69,6 +92,7 @@ impl Default for DstackTdxPolicy {
             os_image_hash: None,
             allowed_tcb_status: default_allowed_tcb_status(),
             grace_period: None,
+            reattestation_interval_secs: DEFAULT_REATTESTATION_INTERVAL_SECS,
             pccs_url: default_pccs_url(),
             cache_collateral: false,
             disable_runtime_verification: false,
@@ -78,7 +102,9 @@ impl Default for DstackTdxPolicy {
 
 /// Check if a string is a valid lowercase hex string.
 fn is_valid_hex(s: &str) -> bool {
-    !s.is_empty() && s.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
 }
 
 impl DstackTdxPolicy {
@@ -105,6 +131,7 @@ impl DstackTdxPolicy {
     /// - `os_image_hash` is a valid hex string (if provided)
     /// - `expected_bootchain` fields are valid hex strings (if provided)
     /// - `grace_period` requires `allowed_tcb_status` to include `OutOfDate`
+    /// - `reattestation_interval_secs` is 0 (disabled) or >= 30 seconds
     pub fn validate(&self) -> Result<(), AtlsVerificationError> {
         // Validate TCB status values
         for status in &self.allowed_tcb_status {
@@ -120,10 +147,19 @@ impl DstackTdxPolicy {
         if self.grace_period.is_some() {
             if !self.allowed_tcb_status.iter().any(|s| s == "OutOfDate") {
                 return Err(AtlsVerificationError::Configuration(
-                    "grace_period requires allowed_tcb_status to include OutOfDate"
-                        .into(),
+                    "grace_period requires allowed_tcb_status to include OutOfDate".into(),
                 ));
             }
+        }
+
+        // Validate re-attestation interval (0 = disabled)
+        if self.reattestation_interval_secs != 0
+            && self.reattestation_interval_secs < MIN_REATTESTATION_INTERVAL_SECS
+        {
+            return Err(AtlsVerificationError::Configuration(format!(
+                "reattestation_interval_secs must be 0 (disabled) or >= {} seconds",
+                MIN_REATTESTATION_INTERVAL_SECS
+            )));
         }
 
         // Validate os_image_hash is hex
@@ -192,6 +228,7 @@ impl IntoVerifier for DstackTdxPolicy {
         if let Some(grace) = self.grace_period {
             builder = builder.grace_period(grace);
         }
+        builder = builder.reattestation_interval_secs(self.reattestation_interval_secs);
 
         if let Some(pccs) = self.pccs_url {
             builder = builder.pccs_url(pccs);
@@ -218,7 +255,9 @@ mod tests {
     #[test]
     fn test_dstack_tdx_policy_dev() {
         let policy = DstackTdxPolicy::dev();
-        assert!(policy.allowed_tcb_status.contains(&"SWHardeningNeeded".to_string()));
+        assert!(policy
+            .allowed_tcb_status
+            .contains(&"SWHardeningNeeded".to_string()));
         assert!(policy.disable_runtime_verification);
     }
 
@@ -322,6 +361,67 @@ mod tests {
         };
         let result = policy.validate();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_reattestation_interval_default() {
+        let policy = DstackTdxPolicy::default();
+        assert_eq!(
+            policy.reattestation_interval_secs,
+            DEFAULT_REATTESTATION_INTERVAL_SECS
+        );
+        // dev() keeps the secure default: freshness is not a runtime relaxation.
+        assert_eq!(
+            DstackTdxPolicy::dev().reattestation_interval_secs,
+            DEFAULT_REATTESTATION_INTERVAL_SECS
+        );
+    }
+
+    #[test]
+    fn test_reattestation_interval_defaults_when_absent_from_json() {
+        let parsed: DstackTdxPolicy =
+            serde_json::from_str(r#"{"disable_runtime_verification": true}"#).unwrap();
+        assert_eq!(
+            parsed.reattestation_interval_secs,
+            DEFAULT_REATTESTATION_INTERVAL_SECS
+        );
+    }
+
+    #[test]
+    fn test_reattestation_interval_roundtrip() {
+        for interval in [0u64, 600] {
+            let policy = DstackTdxPolicy {
+                reattestation_interval_secs: interval,
+                ..Default::default()
+            };
+            let json = serde_json::to_string(&policy).unwrap();
+            assert!(json.contains("reattestation_interval_secs"));
+            let parsed: DstackTdxPolicy = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed.reattestation_interval_secs, interval);
+        }
+    }
+
+    #[test]
+    fn test_reattestation_interval_zero_disables_and_validates() {
+        let policy = DstackTdxPolicy {
+            reattestation_interval_secs: 0,
+            disable_runtime_verification: true,
+            ..Default::default()
+        };
+        assert!(policy.validate().is_ok());
+    }
+
+    #[test]
+    fn test_reattestation_interval_below_minimum_rejected() {
+        let policy = DstackTdxPolicy {
+            reattestation_interval_secs: MIN_REATTESTATION_INTERVAL_SECS - 1,
+            disable_runtime_verification: true,
+            ..Default::default()
+        };
+        let result = policy.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("reattestation_interval_secs"));
     }
 
     #[test]

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -1,7 +1,7 @@
 //! DstackTDXVerifier implementation.
 
 use std::collections::{BTreeMap, HashMap};
-use std::sync::{Arc, RwLock};
+use std::sync::{OnceLock, RwLock};
 
 use dcap_qvl::collateral::get_collateral;
 use dcap_qvl::quote::Quote;
@@ -32,6 +32,59 @@ struct CachedCollateral {
 /// Default collateral cache TTL: 8 hours (in seconds).
 const COLLATERAL_CACHE_TTL_SECS: u64 = 8 * 3600;
 
+/// Process-global collateral cache shared by all verifier instances.
+///
+/// Keyed by (pccs_url, fmspc, ca) so different PCCS providers or platforms
+/// never collide. Entries expire after `COLLATERAL_CACHE_TTL_SECS`. Sharing
+/// across verifiers means reconnects and short-lived verifiers still benefit
+/// from previously fetched collateral (gated by `cache_collateral`).
+static COLLATERAL_CACHE: OnceLock<RwLock<HashMap<CollateralCacheKey, CachedCollateral>>> =
+    OnceLock::new();
+
+fn collateral_cache() -> &'static RwLock<HashMap<CollateralCacheKey, CachedCollateral>> {
+    COLLATERAL_CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Look up collateral in the process-global cache, honoring the TTL.
+fn lookup_cached_collateral(key: &CollateralCacheKey, now_secs: u64) -> Option<QuoteCollateralV3> {
+    match collateral_cache().read() {
+        Ok(guard) => guard.get(key).and_then(|entry| {
+            if now_secs.saturating_sub(entry.cached_at_secs) < COLLATERAL_CACHE_TTL_SECS {
+                Some(entry.collateral.clone())
+            } else {
+                debug!(
+                    "Cached collateral expired for FMSPC={}, CA={}",
+                    key.1, key.2
+                );
+                None
+            }
+        }),
+        Err(_) => {
+            warn!("Collateral cache lock poisoned, treating as cache miss");
+            None
+        }
+    }
+}
+
+/// Store collateral in the process-global cache.
+fn store_cached_collateral(key: CollateralCacheKey, collateral: QuoteCollateralV3, now_secs: u64) {
+    match collateral_cache().write() {
+        Ok(mut guard) => {
+            debug!("Caching collateral for FMSPC={}, CA={}", key.1, key.2);
+            guard.insert(
+                key,
+                CachedCollateral {
+                    collateral,
+                    cached_at_secs: now_secs,
+                },
+            );
+        }
+        Err(_) => {
+            warn!("Collateral cache lock poisoned, skipping cache write");
+        }
+    }
+}
+
 /// Response from the /tdx_quote endpoint.
 #[derive(Debug, serde::Deserialize)]
 struct QuoteEndpointResponse {
@@ -50,8 +103,6 @@ struct QuoteEndpointResponse {
 /// 7. Verify OS image hash
 pub struct DstackTDXVerifier {
     config: DstackTDXVerifierConfig,
-    /// Cached collateral keyed by (pccs_url, fmspc, ca) with TTL expiration.
-    cached_collateral: Arc<RwLock<HashMap<CollateralCacheKey, CachedCollateral>>>,
 }
 
 impl DstackTDXVerifier {
@@ -70,10 +121,7 @@ impl DstackTDXVerifier {
                 ));
             }
         }
-        Ok(Self {
-            config,
-            cached_collateral: Arc::new(RwLock::new(HashMap::new())),
-        })
+        Ok(Self { config })
     }
 
     /// Create a new builder for DstackTDXVerifier.
@@ -93,11 +141,10 @@ impl DstackTDXVerifier {
         // Parse quote to get cache key components (FMSPC and CA)
         let parsed_quote = Quote::parse(quote)
             .map_err(|e| AtlsVerificationError::Quote(format!("Failed to parse quote: {}", e)))?;
-        let fmspc = hex::encode_upper(
-            parsed_quote
-                .fmspc()
-                .map_err(|e| AtlsVerificationError::Quote(format!("Failed to get FMSPC: {}", e)))?,
-        );
+        let fmspc =
+            hex::encode_upper(parsed_quote.fmspc().map_err(|e| {
+                AtlsVerificationError::Quote(format!("Failed to get FMSPC: {}", e))
+            })?);
         let ca = parsed_quote
             .ca()
             .map_err(|e| AtlsVerificationError::Quote(format!("Failed to get CA: {}", e)))?;
@@ -116,22 +163,9 @@ impl DstackTDXVerifier {
         #[cfg(target_arch = "wasm32")]
         let now_secs = (js_sys::Date::now() / 1000.0) as u64;
 
-        // Try to get collateral from cache (with TTL check)
+        // Try to get collateral from the process-global cache (with TTL check)
         let cached = if self.config.cache_collateral {
-            match self.cached_collateral.read() {
-                Ok(guard) => guard.get(&cache_key).and_then(|entry| {
-                    if now_secs.saturating_sub(entry.cached_at_secs) < COLLATERAL_CACHE_TTL_SECS {
-                        Some(entry.collateral.clone())
-                    } else {
-                        debug!("Cached collateral expired for FMSPC={}, CA={}", fmspc, ca);
-                        None
-                    }
-                }),
-                Err(_) => {
-                    warn!("Collateral cache lock poisoned, treating as cache miss");
-                    None
-                }
-            }
+            lookup_cached_collateral(&cache_key, now_secs)
         } else {
             None
         };
@@ -146,26 +180,13 @@ impl DstackTDXVerifier {
             }
             None => {
                 debug!("Fetching collateral from {}", pccs_url);
-                let c = get_collateral(pccs_url, quote)
-                    .await
-                    .map_err(|e| {
-                        AtlsVerificationError::Quote(format!("Failed to get collateral: {}", e))
-                    })?;
+                let c = get_collateral(pccs_url, quote).await.map_err(|e| {
+                    AtlsVerificationError::Quote(format!("Failed to get collateral: {}", e))
+                })?;
 
                 // Cache if enabled
                 if self.config.cache_collateral {
-                    match self.cached_collateral.write() {
-                        Ok(mut guard) => {
-                            debug!("Caching collateral for FMSPC={}, CA={}", fmspc, ca);
-                            guard.insert(cache_key, CachedCollateral {
-                                collateral: c.clone(),
-                                cached_at_secs: now_secs,
-                            });
-                        }
-                        Err(_) => {
-                            warn!("Collateral cache lock poisoned, skipping cache write");
-                        }
-                    }
+                    store_cached_collateral(cache_key, c.clone(), now_secs);
                 }
                 c
             }
@@ -174,8 +195,9 @@ impl DstackTDXVerifier {
         debug!("Collateral received, verifying DCAP quote");
 
         // Verify the quote
-        let report = verify(quote, &collateral, now_secs)
-            .map_err(|e| AtlsVerificationError::Quote(format!("DCAP verification failed: {}", e)))?;
+        let report = verify(quote, &collateral, now_secs).map_err(|e| {
+            AtlsVerificationError::Quote(format!("DCAP verification failed: {}", e))
+        })?;
 
         debug!("DCAP verification complete, TCB status: {}", report.status);
 
@@ -186,10 +208,7 @@ impl DstackTDXVerifier {
             .iter()
             .any(|s| s == &report.status);
 
-        debug!(
-            "TCB status '{}' allowed: {}",
-            report.status, tcb_allowed
-        );
+        debug!("TCB status '{}' allowed: {}", report.status, tcb_allowed);
 
         // If TCB status is OutOfDate, check it's within the grace period (if configured)
         // TODO: enforce_grace_period is currently implemented in a complex manner since
@@ -197,7 +216,13 @@ impl DstackTDXVerifier {
         // extract the TCB date from the quote and collateral manually, which is not ideal.
         // We should update enforce_grace_period when dcap-qvl adds TCB info to the VerifiedReport.
         // This would remove almost all the tdx/grace_period.rs code.
-        enforce_grace_period(&report, &parsed_quote, &collateral, self.config.grace_period, now_secs)?;
+        enforce_grace_period(
+            &report,
+            &parsed_quote,
+            &collateral,
+            self.config.grace_period,
+            now_secs,
+        )?;
 
         if !tcb_allowed {
             return Err(AtlsVerificationError::TcbStatusNotAllowed {
@@ -287,9 +312,7 @@ impl DstackTDXVerifier {
         debug!("Certificate hash: {}", cert_hash);
 
         // Find last "New TLS Certificate" event
-        let cert_event = events
-            .iter()
-            .rfind(|e| e.event == "New TLS Certificate");
+        let cert_event = events.iter().rfind(|e| e.event == "New TLS Certificate");
 
         match cert_event {
             Some(event) => {
@@ -344,11 +367,9 @@ impl DstackTDXVerifier {
         let event = events
             .iter()
             .find(|e| e.event == "compose-hash")
-            .ok_or_else(|| {
-                AtlsVerificationError::AppComposeHashMismatch {
-                    expected: expected.clone(),
-                    actual: "<not found in event log>".to_string(),
-                }
+            .ok_or_else(|| AtlsVerificationError::AppComposeHashMismatch {
+                expected: expected.clone(),
+                actual: "<not found in event log>".to_string(),
             })?;
 
         debug!("App compose hash from event log: {}", event.event_payload);
@@ -494,7 +515,6 @@ impl DstackTDXVerifier {
         debug!("Report data expected: {}", expected);
         debug!("Report data actual:   {}", actual);
 
-        
         if expected != actual {
             return Err(AtlsVerificationError::ReportDataMismatch { expected, actual });
         }
@@ -539,9 +559,9 @@ impl AtlsVerifier for DstackTDXVerifier {
 
         // 4. Verify DCAP quote using dcap-qvl directly
         debug!("Decoding quote for DCAP verification");
-        let quote_bytes = quote_response
-            .decode_quote()
-            .map_err(|e| AtlsVerificationError::Other(anyhow::anyhow!("Failed to decode quote: {}", e)))?;
+        let quote_bytes = quote_response.decode_quote().map_err(|e| {
+            AtlsVerificationError::Other(anyhow::anyhow!("Failed to decode quote: {}", e))
+        })?;
         debug!("Quote decoded ({} bytes)", quote_bytes.len());
 
         // Async quote verification - no blocking!
@@ -549,9 +569,7 @@ impl AtlsVerifier for DstackTDXVerifier {
 
         // 5. Verify report data
         let session_ekm: &[u8; 32] = session_ekm.try_into().map_err(|_| {
-            AtlsVerificationError::Configuration(
-                "session_ekm must be exactly 32 bytes".into(),
-            )
+            AtlsVerificationError::Configuration("session_ekm must be exactly 32 bytes".into())
         })?;
         self.verify_report_data(&nonce, session_ekm, &verified_report)?;
 
@@ -650,13 +668,9 @@ where
         .ok_or_else(|| AtlsVerificationError::Io("Invalid HTTP response".into()))?;
     let response_body = &response_buf[body_start..];
 
-    let response: QuoteEndpointResponse = serde_json::from_slice(response_body)
-        .map_err(|e| {
-            AtlsVerificationError::Quote(format!(
-                "Failed to parse /tdx_quote response: {}",
-                e
-            ))
-        })?;
+    let response: QuoteEndpointResponse = serde_json::from_slice(response_body).map_err(|e| {
+        AtlsVerificationError::Quote(format!("Failed to parse /tdx_quote response: {}", e))
+    })?;
 
     Ok(response.quote)
 }
@@ -681,4 +695,75 @@ fn parse_content_length(headers: &[u8]) -> Option<usize> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn collateral_with_marker(marker: &str) -> QuoteCollateralV3 {
+        QuoteCollateralV3 {
+            pck_crl_issuer_chain: marker.to_string(),
+            root_ca_crl: Vec::new(),
+            pck_crl: Vec::new(),
+            tcb_info_issuer_chain: String::new(),
+            tcb_info: String::new(),
+            tcb_info_signature: Vec::new(),
+            qe_identity_issuer_chain: String::new(),
+            qe_identity: String::new(),
+            qe_identity_signature: Vec::new(),
+            pck_certificate_chain: None,
+        }
+    }
+
+    // The cache is process-global and tests run in parallel, so every test
+    // uses its own unique keys.
+
+    #[test]
+    fn test_collateral_cache_hit_within_ttl() {
+        let key: CollateralCacheKey = (
+            "https://pccs.test/hit".to_string(),
+            "00906ED50000".to_string(),
+            "platform",
+        );
+        store_cached_collateral(key.clone(), collateral_with_marker("hit"), 1_000);
+        let hit = lookup_cached_collateral(&key, 1_000 + COLLATERAL_CACHE_TTL_SECS - 1);
+        assert_eq!(hit.map(|c| c.pck_crl_issuer_chain), Some("hit".to_string()));
+    }
+
+    #[test]
+    fn test_collateral_cache_key_isolation() {
+        let key_a: CollateralCacheKey = (
+            "https://pccs.test/iso-a".to_string(),
+            "00906ED50000".to_string(),
+            "platform",
+        );
+        let key_b: CollateralCacheKey = (
+            "https://pccs.test/iso-b".to_string(),
+            "00906ED50000".to_string(),
+            "platform",
+        );
+        store_cached_collateral(key_a, collateral_with_marker("a"), 1_000);
+        // Same FMSPC/CA but a different PCCS URL must never collide.
+        assert!(lookup_cached_collateral(&key_b, 1_000).is_none());
+    }
+
+    #[test]
+    fn test_collateral_cache_expires_after_ttl() {
+        let key: CollateralCacheKey = (
+            "https://pccs.test/ttl".to_string(),
+            "00906ED50000".to_string(),
+            "processor",
+        );
+        store_cached_collateral(key.clone(), collateral_with_marker("old"), 5_000);
+        assert!(lookup_cached_collateral(&key, 5_000 + COLLATERAL_CACHE_TTL_SECS).is_none());
+
+        // An expired entry can be refreshed in place.
+        store_cached_collateral(key.clone(), collateral_with_marker("new"), 9_000_000);
+        let refreshed = lookup_cached_collateral(&key, 9_000_000);
+        assert_eq!(
+            refreshed.map(|c| c.pck_crl_issuer_chain),
+            Some("new".to_string())
+        );
+    }
 }

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -91,6 +91,42 @@ struct QuoteEndpointResponse {
     quote: GetQuoteResponse,
 }
 
+/// How to match the session certificate against "New TLS Certificate" events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CertEventMatch {
+    /// Require the most recent certificate event to match.
+    ///
+    /// Used for the initial handshake: the connection must present the
+    /// attester's current certificate.
+    Latest,
+    /// Accept any certificate event that matches.
+    ///
+    /// Used for re-attestation: the session certificate stays valid for the
+    /// connection lifetime even if the attester has since rotated to a new
+    /// certificate (rotation appends a new event to the append-only log).
+    #[cfg_attr(not(test), allow(dead_code))] // constructed by re-attestation (next commit)
+    Any,
+}
+
+/// Decode a "New TLS Certificate" event payload into the cert hash string.
+///
+/// The payload is the hex encoding of the UTF-8 hex digest of the certificate.
+fn decode_cert_event_payload(event: &EventLog) -> Result<String, AtlsVerificationError> {
+    let decoded = hex::decode(&event.event_payload).map_err(|e| {
+        AtlsVerificationError::EventLogParse(format!(
+            "failed to hex-decode certificate event payload: {}",
+            e
+        ))
+    })?;
+
+    String::from_utf8(decoded).map_err(|e| {
+        AtlsVerificationError::EventLogParse(format!(
+            "certificate event payload is not valid UTF-8: {}",
+            e
+        ))
+    })
+}
+
 /// DstackTDXVerifier performs TDX attestation verification for dstack deployments.
 ///
 /// This verifier implements the full verification flow:
@@ -151,17 +187,8 @@ impl DstackTDXVerifier {
 
         let cache_key = (pccs_url.to_string(), fmspc.clone(), ca);
 
-        // Get current time - platform specific (needed for cache TTL and verification)
-        #[cfg(not(target_arch = "wasm32"))]
-        let now_secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|e| {
-                AtlsVerificationError::Quote(format!("Failed to get current time: {}", e))
-            })?
-            .as_secs();
-
-        #[cfg(target_arch = "wasm32")]
-        let now_secs = (js_sys::Date::now() / 1000.0) as u64;
+        // Get current time (needed for cache TTL and verification)
+        let now_secs = crate::time::now_secs();
 
         // Try to get collateral from the process-global cache (with TTL check)
         let cached = if self.config.cache_collateral {
@@ -301,43 +328,55 @@ impl DstackTDXVerifier {
 
     /// Verify certificate is in event log (using dstack-sdk EventLog type).
     ///
+    /// `mode` selects whether only the latest certificate event may match
+    /// (initial handshake) or any certificate event (re-attestation).
+    ///
     /// Returns Ok(true) if cert matches, Ok(false) if cert not found,
     /// or Err if parsing fails.
     fn verify_cert_in_eventlog(
         &self,
         cert_der: &[u8],
         events: &[EventLog],
+        mode: CertEventMatch,
     ) -> Result<bool, AtlsVerificationError> {
         let cert_hash = hex::encode(Sha256::digest(cert_der));
         debug!("Certificate hash: {}", cert_hash);
 
-        // Find last "New TLS Certificate" event
-        let cert_event = events.iter().rfind(|e| e.event == "New TLS Certificate");
+        match mode {
+            CertEventMatch::Latest => {
+                // Find last "New TLS Certificate" event
+                let cert_event = events.iter().rfind(|e| e.event == "New TLS Certificate");
 
-        match cert_event {
-            Some(event) => {
-                // event_payload is hex-encoded, decode it to get the cert hash string
-                let decoded = hex::decode(&event.event_payload).map_err(|e| {
-                    AtlsVerificationError::EventLogParse(format!(
-                        "failed to hex-decode certificate event payload: {}",
-                        e
-                    ))
-                })?;
-
-                let eventlog_cert_hash = String::from_utf8(decoded).map_err(|e| {
-                    AtlsVerificationError::EventLogParse(format!(
-                        "certificate event payload is not valid UTF-8: {}",
-                        e
-                    ))
-                })?;
-
-                debug!("Certificate hash from event log: {}", eventlog_cert_hash);
-                let cert_match = eventlog_cert_hash == cert_hash;
-                debug!("Certificate hash match: {}", cert_match);
-                Ok(cert_match)
+                match cert_event {
+                    Some(event) => {
+                        let eventlog_cert_hash = decode_cert_event_payload(event)?;
+                        debug!("Certificate hash from event log: {}", eventlog_cert_hash);
+                        let cert_match = eventlog_cert_hash == cert_hash;
+                        debug!("Certificate hash match: {}", cert_match);
+                        Ok(cert_match)
+                    }
+                    None => {
+                        debug!("No 'New TLS Certificate' event found in event log");
+                        Ok(false)
+                    }
+                }
             }
-            None => {
-                debug!("No 'New TLS Certificate' event found in event log");
+            CertEventMatch::Any => {
+                let mut found_any_event = false;
+                for event in events.iter().filter(|e| e.event == "New TLS Certificate") {
+                    found_any_event = true;
+                    // Malformed payloads stay strict errors in both modes.
+                    let eventlog_cert_hash = decode_cert_event_payload(event)?;
+                    if eventlog_cert_hash == cert_hash {
+                        debug!("Certificate hash matched an event log entry");
+                        return Ok(true);
+                    }
+                }
+                if !found_any_event {
+                    debug!("No 'New TLS Certificate' event found in event log");
+                } else {
+                    debug!("No certificate event matched the session certificate");
+                }
                 Ok(false)
             }
         }
@@ -522,15 +561,20 @@ impl DstackTDXVerifier {
         debug!("Report data verification successful");
         Ok(())
     }
-}
 
-impl AtlsVerifier for DstackTDXVerifier {
-    async fn verify<S>(
+    /// Full verification: fetch a fresh quote in-band over `stream`, then
+    /// appraise it.
+    ///
+    /// `cert_match` selects how the session certificate is matched against
+    /// the event log (`Latest` for initial handshakes, `Any` for
+    /// re-attestation of an established session).
+    pub(crate) async fn verify_with_mode<S>(
         &self,
         stream: &mut S,
         peer_cert: &[u8],
         session_ekm: &[u8],
         hostname: &str,
+        cert_match: CertEventMatch,
     ) -> Result<Report, AtlsVerificationError>
     where
         S: AsyncByteStream,
@@ -539,10 +583,26 @@ impl AtlsVerifier for DstackTDXVerifier {
 
         // 1. Generate nonce and get quote via HTTP POST to /tdx_quote
         let nonce: [u8; 32] = rand::random();
-
-        // Get quote via HTTP POST to /tdx_quote
         let quote_response = get_quote_over_http(stream, &nonce, hostname).await?;
 
+        self.appraise(&quote_response, &nonce, peer_cert, session_ekm, cert_match)
+            .await
+    }
+
+    /// Appraise a quote response: event log decode, certificate binding,
+    /// DCAP verification, report data (nonce + EKM), RTMR replay, and —
+    /// unless disabled — bootchain, app compose, and OS image checks.
+    ///
+    /// Every check runs in full on each call; re-attestation repeats the
+    /// exact appraisal performed at connect time.
+    async fn appraise(
+        &self,
+        quote_response: &GetQuoteResponse,
+        nonce: &[u8; 32],
+        peer_cert: &[u8],
+        session_ekm: &[u8],
+        cert_match: CertEventMatch,
+    ) -> Result<Report, AtlsVerificationError> {
         // 2. Parse event log using dstack-sdk-types
         debug!("Parsing event log");
         let events = quote_response
@@ -552,7 +612,7 @@ impl AtlsVerifier for DstackTDXVerifier {
 
         // 3. Verify certificate in event log
         debug!("Verifying certificate in event log");
-        let cert_in_eventlog = self.verify_cert_in_eventlog(peer_cert, &events)?;
+        let cert_in_eventlog = self.verify_cert_in_eventlog(peer_cert, &events, cert_match)?;
         if !cert_in_eventlog {
             return Err(AtlsVerificationError::CertificateNotInEventLog);
         }
@@ -571,10 +631,10 @@ impl AtlsVerifier for DstackTDXVerifier {
         let session_ekm: &[u8; 32] = session_ekm.try_into().map_err(|_| {
             AtlsVerificationError::Configuration("session_ekm must be exactly 32 bytes".into())
         })?;
-        self.verify_report_data(&nonce, session_ekm, &verified_report)?;
+        self.verify_report_data(nonce, session_ekm, &verified_report)?;
 
         // 6. Verify RTMR replay against the verified report
-        self.verify_rtmr_replay(&quote_response, &verified_report)?;
+        self.verify_rtmr_replay(quote_response, &verified_report)?;
 
         // Skip remaining checks if runtime verification is disabled
         if self.config.disable_runtime_verification {
@@ -593,6 +653,28 @@ impl AtlsVerifier for DstackTDXVerifier {
 
         debug!("DStack TDX verification complete");
         Ok(Report::Tdx(verified_report))
+    }
+}
+
+impl AtlsVerifier for DstackTDXVerifier {
+    async fn verify<S>(
+        &self,
+        stream: &mut S,
+        peer_cert: &[u8],
+        session_ekm: &[u8],
+        hostname: &str,
+    ) -> Result<Report, AtlsVerificationError>
+    where
+        S: AsyncByteStream,
+    {
+        self.verify_with_mode(
+            stream,
+            peer_cert,
+            session_ekm,
+            hostname,
+            CertEventMatch::Latest,
+        )
+        .await
     }
 }
 
@@ -713,6 +795,83 @@ mod tests {
             qe_identity: String::new(),
             qe_identity_signature: Vec::new(),
             pck_certificate_chain: None,
+        }
+    }
+
+    fn cert_event(cert_der: &[u8]) -> EventLog {
+        let cert_hash = hex::encode(Sha256::digest(cert_der));
+        EventLog {
+            imr: 3,
+            event_type: 0x0800_0001,
+            digest: String::new(),
+            event: "New TLS Certificate".to_string(),
+            event_payload: hex::encode(cert_hash.as_bytes()),
+        }
+    }
+
+    fn test_verifier() -> DstackTDXVerifier {
+        DstackTDXVerifier::builder()
+            .disable_runtime_verification()
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_cert_event_match_latest_requires_most_recent_event() {
+        let verifier = test_verifier();
+        let session_cert = b"session-cert-der";
+        let rotated_cert = b"rotated-cert-der";
+        // The session cert was logged first; a rotation appended a newer event.
+        let events = vec![cert_event(session_cert), cert_event(rotated_cert)];
+
+        assert!(!verifier
+            .verify_cert_in_eventlog(session_cert, &events, CertEventMatch::Latest)
+            .unwrap());
+        assert!(verifier
+            .verify_cert_in_eventlog(rotated_cert, &events, CertEventMatch::Latest)
+            .unwrap());
+    }
+
+    #[test]
+    fn test_cert_event_match_any_accepts_earlier_session_cert() {
+        let verifier = test_verifier();
+        let session_cert = b"session-cert-der";
+        let rotated_cert = b"rotated-cert-der";
+        let events = vec![cert_event(session_cert), cert_event(rotated_cert)];
+
+        assert!(verifier
+            .verify_cert_in_eventlog(session_cert, &events, CertEventMatch::Any)
+            .unwrap());
+        // A cert that was never logged still fails.
+        assert!(!verifier
+            .verify_cert_in_eventlog(b"unknown-cert", &events, CertEventMatch::Any)
+            .unwrap());
+    }
+
+    #[test]
+    fn test_cert_event_match_without_cert_events() {
+        let verifier = test_verifier();
+        let events: Vec<EventLog> = Vec::new();
+        assert!(!verifier
+            .verify_cert_in_eventlog(b"cert", &events, CertEventMatch::Latest)
+            .unwrap());
+        assert!(!verifier
+            .verify_cert_in_eventlog(b"cert", &events, CertEventMatch::Any)
+            .unwrap());
+    }
+
+    #[test]
+    fn test_cert_event_malformed_payload_errors_in_both_modes() {
+        let verifier = test_verifier();
+        let mut event = cert_event(b"cert");
+        event.event_payload = "not-hex!".to_string();
+        let events = vec![event];
+
+        for mode in [CertEventMatch::Latest, CertEventMatch::Any] {
+            let err = verifier
+                .verify_cert_in_eventlog(b"cert", &events, mode)
+                .unwrap_err();
+            assert!(matches!(err, AtlsVerificationError::EventLogParse(_)));
         }
     }
 

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -32,12 +32,23 @@ struct CachedCollateral {
 /// Default collateral cache TTL: 8 hours (in seconds).
 const COLLATERAL_CACHE_TTL_SECS: u64 = 8 * 3600;
 
+/// Quote certification-data type carrying the full PCK certificate chain
+/// (mirrors dcap-qvl's private `constants::PCK_CERT_CHAIN`).
+const QUOTE_CERT_TYPE_PCK_CERT_CHAIN: u16 = 5;
+
 /// Process-global collateral cache shared by all verifier instances.
 ///
 /// Keyed by (pccs_url, fmspc, ca) so different PCCS providers or platforms
 /// never collide. Entries expire after `COLLATERAL_CACHE_TTL_SECS`. Sharing
 /// across verifiers means reconnects and short-lived verifiers still benefit
 /// from previously fetched collateral (gated by `cache_collateral`).
+///
+/// Entries hold only machine-independent collateral (TCB info, QE identity,
+/// CRLs): `pck_certificate_chain` is per-machine — dcap-qvl embeds the
+/// fetching quote's own chain and its `verify()` prefers it over the chain
+/// inside the quote under verification — so it is stripped before caching.
+/// Otherwise a quote from one machine could be verified against another
+/// machine's PCK chain (same FMSPC/CA) and false-fail for up to the TTL.
 static COLLATERAL_CACHE: OnceLock<RwLock<HashMap<CollateralCacheKey, CachedCollateral>>> =
     OnceLock::new();
 
@@ -66,8 +77,15 @@ fn lookup_cached_collateral(key: &CollateralCacheKey, now_secs: u64) -> Option<Q
     }
 }
 
-/// Store collateral in the process-global cache.
+/// Store collateral in the process-global cache, stripping the per-machine
+/// PCK certificate chain so the entry is shareable across machines with the
+/// same (pccs_url, fmspc, ca). Consumers verify against the chain embedded
+/// in their own quote instead.
 fn store_cached_collateral(key: CollateralCacheKey, collateral: QuoteCollateralV3, now_secs: u64) {
+    let collateral = QuoteCollateralV3 {
+        pck_certificate_chain: None,
+        ..collateral
+    };
     match collateral_cache().write() {
         Ok(mut guard) => {
             debug!("Caching collateral for FMSPC={}, CA={}", key.1, key.2);
@@ -189,8 +207,17 @@ impl DstackTDXVerifier {
         // Get current time (needed for cache TTL and verification)
         let now_secs = crate::time::now_secs();
 
+        // Cached collateral has its per-machine PCK chain stripped (see
+        // store_cached_collateral), so dcap-qvl's verify() falls back to the
+        // chain embedded in *this* quote. That fallback only exists for
+        // quotes that carry their own chain (cert_type 5), so the cache is
+        // bypassed entirely for other certification data types.
+        let quote_embeds_pck_chain =
+            parsed_quote.inner_cert_type() == QUOTE_CERT_TYPE_PCK_CERT_CHAIN;
+        let use_cache = self.config.cache_collateral && quote_embeds_pck_chain;
+
         // Try to get collateral from the process-global cache (with TTL check)
-        let cached = if self.config.cache_collateral {
+        let cached = if use_cache {
             lookup_cached_collateral(&cache_key, now_secs)
         } else {
             None
@@ -210,8 +237,8 @@ impl DstackTDXVerifier {
                     AtlsVerificationError::Quote(format!("Failed to get collateral: {}", e))
                 })?;
 
-                // Cache if enabled
-                if self.config.cache_collateral {
+                // Cache if enabled (per-machine PCK chain is stripped inside)
+                if use_cache {
                     store_cached_collateral(cache_key, c.clone(), now_secs);
                 }
                 c
@@ -930,6 +957,30 @@ mod tests {
         store_cached_collateral(key_a, collateral_with_marker("a"), 1_000);
         // Same FMSPC/CA but a different PCCS URL must never collide.
         assert!(lookup_cached_collateral(&key_b, 1_000).is_none());
+    }
+
+    #[test]
+    fn test_collateral_cache_strips_per_machine_pck_chain() {
+        let key: CollateralCacheKey = (
+            "https://pccs.test/pck-strip".to_string(),
+            "00906ED50000".to_string(),
+            "platform",
+        );
+        // Collateral fetched while verifying machine A embeds A's PCK chain
+        // (dcap-qvl's get_collateral attaches the fetching quote's chain).
+        let mut collateral = collateral_with_marker("shared");
+        collateral.pck_certificate_chain = Some("machine-a-pck-chain".to_string());
+        store_cached_collateral(key.clone(), collateral, 1_000);
+
+        // A later cache hit (e.g. while verifying machine B's quote, or
+        // machine A after a PCK rotation) must not carry the stored chain:
+        // verify() would prefer it over the chain embedded in the quote
+        // under verification. With it stripped, verification falls back to
+        // the quote's own chain.
+        let hit = lookup_cached_collateral(&key, 1_000).expect("cache hit expected");
+        assert_eq!(hit.pck_certificate_chain, None);
+        // Machine-independent collateral is preserved.
+        assert_eq!(hit.pck_crl_issuer_chain, "shared");
     }
 
     #[test]

--- a/core/src/dstack/verifier.rs
+++ b/core/src/dstack/verifier.rs
@@ -104,7 +104,6 @@ pub(crate) enum CertEventMatch {
     /// Used for re-attestation: the session certificate stays valid for the
     /// connection lifetime even if the attester has since rotated to a new
     /// certificate (rotation appends a new event to the append-only log).
-    #[cfg_attr(not(test), allow(dead_code))] // constructed by re-attestation (next commit)
     Any,
 }
 
@@ -586,6 +585,32 @@ impl DstackTDXVerifier {
         let quote_response = get_quote_over_http(stream, &nonce, hostname).await?;
 
         self.appraise(&quote_response, &nonce, peer_cert, session_ekm, cert_match)
+            .await
+    }
+
+    /// Configured re-attestation interval in seconds (0 = disabled).
+    pub(crate) fn reattestation_interval_secs(&self) -> u64 {
+        self.config.reattestation_interval_secs
+    }
+
+    /// Appraise a `/tdx_quote` response body (raw JSON bytes) fetched by the
+    /// caller over its own transport (e.g. an HTTP client owning the stream).
+    ///
+    /// The caller supplies the `nonce` it sent with the quote request; the
+    /// appraisal enforces `report_data == SHA512(nonce || session_ekm)`.
+    pub(crate) async fn appraise_quote_body(
+        &self,
+        body: &[u8],
+        nonce: &[u8; 32],
+        peer_cert: &[u8],
+        session_ekm: &[u8],
+        cert_match: CertEventMatch,
+    ) -> Result<Report, AtlsVerificationError> {
+        let response: QuoteEndpointResponse = serde_json::from_slice(body).map_err(|e| {
+            AtlsVerificationError::Quote(format!("Failed to parse /tdx_quote response: {}", e))
+        })?;
+
+        self.appraise(&response.quote, nonce, peer_cert, session_ekm, cert_match)
             .await
     }
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -54,7 +54,10 @@ pub enum AtlsVerificationError {
 
     /// TCB status not in allowed list.
     #[error("TCB status {status} not allowed (allowed: {allowed:?})")]
-    TcbStatusNotAllowed { status: String, allowed: Vec<String> },
+    TcbStatusNotAllowed {
+        status: String,
+        allowed: Vec<String>,
+    },
 
     /// TCB info could not be determined or parsed.
     #[error("TCB info error: {0}")]
@@ -69,7 +72,9 @@ pub enum AtlsVerificationError {
     },
 
     /// Report data mismatch - potential replay attack.
-    #[error("report data mismatch: expected {expected}, got {actual}. Possible replay/relay attack.")]
+    #[error(
+        "report data mismatch: expected {expected}, got {actual}. Possible replay/relay attack."
+    )]
     ReportDataMismatch { expected: String, actual: String },
 
     /// Configuration error.
@@ -87,6 +92,17 @@ pub enum AtlsVerificationError {
     /// Missing server certificate after TLS handshake.
     #[error("missing server certificate")]
     MissingCertificate,
+
+    /// Re-attestation of an established connection failed.
+    ///
+    /// The connection must be treated as unverified and not used further
+    /// (fail closed). The source error distinguishes transport failures
+    /// from verification failures.
+    #[error("re-attestation failed: {source}")]
+    Reattestation {
+        #[source]
+        source: Box<AtlsVerificationError>,
+    },
 
     /// Other errors.
     #[error("{0}")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -86,13 +86,15 @@ pub mod dstack;
 pub mod error;
 pub mod logging;
 pub mod policy;
+pub mod reattest;
 pub mod tdx;
 pub(crate) mod time;
 pub mod verifier;
 
 // High-level API
-pub use connect::{atls_connect, TlsStream};
+pub use connect::{atls_connect, atls_connect_with_reattester, TlsStream};
 pub use policy::Policy;
+pub use reattest::{ReattestRequest, Reattester};
 
 // Dstack-specific (backward compatible re-exports)
 // NOTE: compose_hash NOT exposed at root - access via dstack::compose_hash

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -87,6 +87,7 @@ pub mod error;
 pub mod logging;
 pub mod policy;
 pub mod tdx;
+pub(crate) mod time;
 pub mod verifier;
 
 // High-level API
@@ -95,7 +96,9 @@ pub use policy::Policy;
 
 // Dstack-specific (backward compatible re-exports)
 // NOTE: compose_hash NOT exposed at root - access via dstack::compose_hash
-pub use dstack::{DstackTDXVerifier, DstackTDXVerifierBuilder, DstackTDXVerifierConfig, DstackTdxPolicy};
+pub use dstack::{
+    DstackTDXVerifier, DstackTDXVerifierBuilder, DstackTDXVerifierConfig, DstackTdxPolicy,
+};
 
 // Generic TDX
 pub use tdx::{ExpectedBootchain, TCB_STATUS_LIST};
@@ -103,8 +106,8 @@ pub use tdx::{ExpectedBootchain, TCB_STATUS_LIST};
 // Low-level API
 pub use error::AtlsVerificationError;
 pub use verifier::{
-    AsyncByteStream, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, IntoVerifier, AtlsVerifier,
-    Report, Verifier,
+    AsyncByteStream, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, AtlsVerifier,
+    IntoVerifier, Report, Verifier,
 };
 
 // Re-export VerifiedReport from dcap-qvl for bindings

--- a/core/src/policy.rs
+++ b/core/src/policy.rs
@@ -56,9 +56,7 @@ impl Policy {
     /// ```
     pub fn into_verifier(self) -> Result<Verifier, AtlsVerificationError> {
         match self {
-            Policy::DstackTdx(policy) => {
-                Ok(Verifier::DstackTdx(policy.into_verifier()?))
-            }
+            Policy::DstackTdx(policy) => Ok(Verifier::DstackTdx(policy.into_verifier()?)),
         }
     }
 }
@@ -83,7 +81,9 @@ mod tests {
         let policy = Policy::DstackTdx(DstackTdxPolicy::dev());
         match policy {
             Policy::DstackTdx(tdx) => {
-                assert!(tdx.allowed_tcb_status.contains(&"SWHardeningNeeded".to_string()));
+                assert!(tdx
+                    .allowed_tcb_status
+                    .contains(&"SWHardeningNeeded".to_string()));
             }
         }
     }

--- a/core/src/reattest.rs
+++ b/core/src/reattest.rs
@@ -20,7 +20,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::error::AtlsVerificationError;
-use crate::time::now_secs;
+use crate::time::mono_millis;
 use crate::verifier::{AsyncByteStream, Report, Verifier};
 
 /// Whether evidence of `age_secs` is due for re-attestation.
@@ -28,6 +28,19 @@ use crate::verifier::{AsyncByteStream, Report, Verifier};
 /// An interval of 0 disables re-attestation entirely.
 fn due(age_secs: u64, interval_secs: u64) -> bool {
     interval_secs != 0 && age_secs >= interval_secs
+}
+
+/// Evidence age in seconds from monotonic-clock readings.
+///
+/// If the clock appears to have moved backwards (possible only with the wasm
+/// `Date.now()` fallback; the native `Instant` source is monotonic), the
+/// evidence is treated as maximally stale so re-attestation triggers
+/// (fail closed) rather than the age silently reading as zero.
+fn age_secs(now_millis: u64, verified_at_millis: u64) -> u64 {
+    if now_millis < verified_at_millis {
+        return u64::MAX;
+    }
+    (now_millis - verified_at_millis) / 1000
 }
 
 /// Re-attestation handle for an established aTLS connection.
@@ -56,8 +69,9 @@ pub struct Reattester {
     session_ekm: Vec<u8>,
     server_name: String,
     interval_secs: u64,
-    /// UNIX seconds of the last successful verification.
-    verified_at_secs: AtomicU64,
+    /// Monotonic-clock milliseconds ([`mono_millis`]) of the last successful
+    /// verification, so wall-clock steps cannot shrink the evidence age.
+    verified_at_millis: AtomicU64,
 }
 
 impl Reattester {
@@ -78,7 +92,7 @@ impl Reattester {
             session_ekm,
             server_name,
             interval_secs,
-            verified_at_secs: AtomicU64::new(now_secs()),
+            verified_at_millis: AtomicU64::new(mono_millis()),
         }
     }
 
@@ -92,9 +106,14 @@ impl Reattester {
         self.interval_secs
     }
 
-    /// Age in seconds of the current attestation evidence.
+    /// Age in seconds of the current attestation evidence, measured on a
+    /// monotonic clock. Reads as maximally stale if the clock ever appears
+    /// to move backwards (wasm `Date.now()` fallback only).
     pub fn evidence_age_secs(&self) -> u64 {
-        now_secs().saturating_sub(self.verified_at_secs.load(Ordering::Acquire))
+        age_secs(
+            mono_millis(),
+            self.verified_at_millis.load(Ordering::Acquire),
+        )
     }
 
     /// Whether the attestation evidence is older than the configured
@@ -170,7 +189,8 @@ impl Reattester {
     ) -> Result<Report, AtlsVerificationError> {
         match result {
             Ok(report) => {
-                self.verified_at_secs.store(now_secs(), Ordering::Release);
+                self.verified_at_millis
+                    .store(mono_millis(), Ordering::Release);
                 Ok(report)
             }
             Err(source) => Err(AtlsVerificationError::Reattestation {
@@ -233,8 +253,8 @@ mod tests {
 
     fn backdate(reattester: &Reattester, secs: u64) {
         reattester
-            .verified_at_secs
-            .store(now_secs().saturating_sub(secs), Ordering::Release);
+            .verified_at_millis
+            .store(mono_millis().saturating_sub(secs * 1000), Ordering::Release);
     }
 
     /// Read one HTTP request (headers + Content-Length body) from the stream.
@@ -295,6 +315,36 @@ mod tests {
         assert!(!due(299, 300));
         assert!(due(300, 300));
         assert!(due(301, 300));
+    }
+
+    #[test]
+    fn test_age_secs_clock_rollback_is_maximally_stale() {
+        // An apparent backwards clock step (possible only with the wasm
+        // Date.now() fallback) must read as stale, never as fresh.
+        assert_eq!(age_secs(1_000, 2_000), u64::MAX);
+        assert!(due(age_secs(1_000, 2_000), 300));
+        // Disabled re-attestation stays disabled even on rollback.
+        assert!(!due(age_secs(1_000, 2_000), 0));
+        // Normal forward progression.
+        assert_eq!(age_secs(301_000, 1_000), 300);
+        assert_eq!(age_secs(1_000, 1_000), 0);
+    }
+
+    #[test]
+    fn test_is_due_after_clock_rollback() {
+        let reattester = test_reattester(300);
+        // Simulate a verification stamped "in the future" relative to the
+        // current monotonic reading (i.e. the clock rolled back).
+        reattester
+            .verified_at_millis
+            .store(mono_millis() + 3_600_000, Ordering::Release);
+        assert!(reattester.is_due(), "rollback must fail closed");
+
+        let disabled = test_reattester(0);
+        disabled
+            .verified_at_millis
+            .store(mono_millis() + 3_600_000, Ordering::Release);
+        assert!(!disabled.is_due(), "interval 0 stays disabled on rollback");
     }
 
     #[test]

--- a/core/src/reattest.rs
+++ b/core/src/reattest.rs
@@ -564,9 +564,11 @@ mod tests {
         assert!(reattester.is_due());
 
         // A request issued long ago (delayed completion) that fails appraisal
-        // must not refresh anything.
+        // must not refresh anything. The nonce value is irrelevant here (the
+        // body fails to parse before the nonce is used); use a random one as
+        // begin() would.
         let stale_request = ReattestRequest {
-            nonce: [0u8; 32],
+            nonce: rand::random(),
             issued_at_millis: mono_millis().saturating_sub(1_000_000),
         };
         let err = reattester

--- a/core/src/reattest.rs
+++ b/core/src/reattest.rs
@@ -75,15 +75,35 @@ pub struct Reattester {
 }
 
 impl Reattester {
-    /// Create a handle for a connection that was verified just now.
+    /// Create a handle for a session that was verified just now.
     ///
     /// The interval is read from the verifier's policy
     /// (`reattestation_interval_secs`; 0 disables re-attestation).
-    pub(crate) fn new(
+    ///
+    /// Public for custom integrations that perform the handshake and initial
+    /// verification manually (via [`tls_handshake`](crate::connect::tls_handshake)
+    /// and [`AtlsVerifier::verify`](crate::AtlsVerifier::verify)); prefer
+    /// [`atls_connect_with_reattester`](crate::atls_connect_with_reattester),
+    /// which constructs the handle with the exact session material.
+    pub fn new(
         verifier: Verifier,
         peer_cert: Vec<u8>,
         session_ekm: Vec<u8>,
         server_name: String,
+    ) -> Self {
+        let now = mono_millis();
+        Self::new_at(verifier, peer_cert, session_ekm, server_name, now)
+    }
+
+    /// Create a handle anchored at `verified_at_millis` — the moment the
+    /// initial verification *started* (nonce issuance), not when it
+    /// completed, so a slow exchange cannot overstate freshness.
+    pub(crate) fn new_at(
+        verifier: Verifier,
+        peer_cert: Vec<u8>,
+        session_ekm: Vec<u8>,
+        server_name: String,
+        verified_at_millis: u64,
     ) -> Self {
         let interval_secs = verifier.reattestation_interval_secs();
         Self {
@@ -92,7 +112,7 @@ impl Reattester {
             session_ekm,
             server_name,
             interval_secs,
-            verified_at_millis: AtomicU64::new(mono_millis()),
+            verified_at_millis: AtomicU64::new(verified_at_millis),
         }
     }
 
@@ -129,12 +149,14 @@ impl Reattester {
     /// Sends a `POST /tdx_quote` request with a fresh nonce on the live
     /// stream and runs the full verification pipeline on the response. The
     /// stream must be quiescent (see the type-level docs). On success the
-    /// evidence age resets; on failure it does not and the connection must
-    /// not be used further.
+    /// evidence age is anchored at the moment the exchange *started* (so a
+    /// slow exchange cannot overstate freshness); on failure it does not
+    /// change and the connection must not be used further.
     pub async fn reattest<S>(&self, stream: &mut S) -> Result<Report, AtlsVerificationError>
     where
         S: AsyncByteStream,
     {
+        let issued_at_millis = mono_millis();
         let result = self
             .verifier
             .reverify(
@@ -144,7 +166,7 @@ impl Reattester {
                 &self.server_name,
             )
             .await;
-        self.finish_result(result)
+        self.finish_result(result, issued_at_millis)
     }
 
     /// Begin a re-attestation exchange over a caller-owned transport.
@@ -152,10 +174,12 @@ impl Reattester {
     /// Use this when the raw stream is not directly accessible (e.g. it is
     /// owned by an HTTP client): send an HTTP request built from the
     /// returned [`ReattestRequest`] to the attester, then pass the response
-    /// body to [`finish`](Self::finish).
+    /// body to [`finish`](Self::finish). The request records its issuance
+    /// time; on success the evidence age is anchored there.
     pub fn begin(&self) -> ReattestRequest {
         ReattestRequest {
             nonce: rand::random(),
+            issued_at_millis: mono_millis(),
         }
     }
 
@@ -165,9 +189,14 @@ impl Reattester {
     /// Runs the full verification pipeline; the response must prove
     /// `report_data == SHA512(nonce || session_ekm)` for the nonce issued by
     /// `begin`. Same success/failure semantics as [`reattest`](Self::reattest).
+    ///
+    /// Consumes the request: a completed exchange cannot be replayed to
+    /// refresh the evidence age again, and the age is anchored at the
+    /// request's issuance time — a delayed or out-of-order completion can
+    /// never make evidence look fresher than a newer one already recorded.
     pub async fn finish(
         &self,
-        request: &ReattestRequest,
+        request: ReattestRequest,
         response_body: &[u8],
     ) -> Result<Report, AtlsVerificationError> {
         let result = self
@@ -179,18 +208,18 @@ impl Reattester {
                 &self.session_ekm,
             )
             .await;
-        self.finish_result(result)
+        self.finish_result(result, request.issued_at_millis)
     }
 
-    /// Record success (refresh evidence age) or wrap failure.
+    /// Record success (anchor evidence age at issuance) or wrap failure.
     fn finish_result(
         &self,
         result: Result<Report, AtlsVerificationError>,
+        issued_at_millis: u64,
     ) -> Result<Report, AtlsVerificationError> {
         match result {
             Ok(report) => {
-                self.verified_at_millis
-                    .store(mono_millis(), Ordering::Release);
+                self.record_verified_at(issued_at_millis);
                 Ok(report)
             }
             Err(source) => Err(AtlsVerificationError::Reattestation {
@@ -198,15 +227,26 @@ impl Reattester {
             }),
         }
     }
+
+    /// Advance the last-verified time to `issued_at_millis`, never backwards:
+    /// an older exchange completing late must not shadow a newer success.
+    fn record_verified_at(&self, issued_at_millis: u64) {
+        self.verified_at_millis
+            .fetch_max(issued_at_millis, Ordering::AcqRel);
+    }
 }
 
 /// A prepared re-attestation request for caller-owned transports.
 ///
 /// Holds the fresh nonce (kept private so it cannot be tampered with between
-/// [`Reattester::begin`] and [`Reattester::finish`]) plus helpers describing
-/// the HTTP request to send to the attester.
+/// [`Reattester::begin`] and [`Reattester::finish`]) and its issuance time,
+/// plus helpers describing the HTTP request to send to the attester.
+///
+/// Deliberately neither `Clone` nor `Copy`: [`Reattester::finish`] consumes
+/// it, so one issued nonce can complete at most one exchange.
 pub struct ReattestRequest {
     nonce: [u8; 32],
+    issued_at_millis: u64,
 }
 
 impl ReattestRequest {
@@ -479,12 +519,64 @@ mod tests {
         let reattester = test_reattester(300);
         let request = reattester.begin();
 
-        let err = reattester.finish(&request, b"not json").await.unwrap_err();
+        let err = reattester.finish(request, b"not json").await.unwrap_err();
         match err {
             AtlsVerificationError::Reattestation { source } => {
                 assert!(matches!(*source, AtlsVerificationError::Quote(_)));
             }
             other => panic!("expected Reattestation error, got: {other}"),
         }
+    }
+
+    #[test]
+    fn test_begin_stamps_issuance_time() {
+        let reattester = test_reattester(300);
+        let before = mono_millis();
+        let request = reattester.begin();
+        let after = mono_millis();
+        assert!(request.issued_at_millis >= before);
+        assert!(request.issued_at_millis <= after);
+    }
+
+    #[test]
+    fn test_record_verified_at_never_regresses() {
+        let reattester = test_reattester(300);
+        let newer = mono_millis() + 10_000;
+        let older = newer - 5_000;
+
+        // A newer exchange completes first...
+        reattester.record_verified_at(newer);
+        // ...then an older-issued exchange completes late: it must not make
+        // the evidence look fresher than the newer success, nor roll it back.
+        reattester.record_verified_at(older);
+
+        assert_eq!(
+            reattester.verified_at_millis.load(Ordering::Acquire),
+            newer,
+            "out-of-order completion must not shadow a newer success"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delayed_failed_completion_keeps_evidence_stale() {
+        let reattester = test_reattester(300);
+        backdate(&reattester, 400);
+        assert!(reattester.is_due());
+
+        // A request issued long ago (delayed completion) that fails appraisal
+        // must not refresh anything.
+        let stale_request = ReattestRequest {
+            nonce: [0u8; 32],
+            issued_at_millis: mono_millis().saturating_sub(1_000_000),
+        };
+        let err = reattester
+            .finish(stale_request, b"not json")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AtlsVerificationError::Reattestation { .. }));
+        assert!(reattester.is_due(), "failed completion must keep staleness");
+        // Note: replaying a completed exchange is prevented at compile time —
+        // `finish` consumes the `ReattestRequest`, which is neither Clone nor
+        // Copy.
     }
 }

--- a/core/src/reattest.rs
+++ b/core/src/reattest.rs
@@ -1,0 +1,440 @@
+//! Client-side re-attestation of established aTLS connections.
+//!
+//! [`Reattester`] retains everything needed to re-verify a connection after
+//! [`atls_connect_with_reattester`](crate::atls_connect_with_reattester)
+//! returns: the verifier (with its policy), the session peer certificate,
+//! the session EKM, and the time of the last successful verification.
+//!
+//! Re-attestation repeats the full verification pipeline with a fresh nonce
+//! bound to the same session EKM (`report_data = SHA512(nonce || ekm)`), so
+//! each cycle carries the same security weight as the initial attestation.
+//! The session EKM never leaves the TLS endpoints, so reusing it across
+//! rounds is sound — it is exactly what binds the fresh evidence to *this*
+//! live session (RFC 9266 channel binding).
+//!
+//! There are no background timers: callers check [`Reattester::is_due`] at
+//! safe message boundaries (no request/response in flight) and re-attest
+//! lazily. The configured interval is therefore the maximum age of the
+//! attestation evidence at the moment the connection is used.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::error::AtlsVerificationError;
+use crate::time::now_secs;
+use crate::verifier::{AsyncByteStream, Report, Verifier};
+
+/// Whether evidence of `age_secs` is due for re-attestation.
+///
+/// An interval of 0 disables re-attestation entirely.
+fn due(age_secs: u64, interval_secs: u64) -> bool {
+    interval_secs != 0 && age_secs >= interval_secs
+}
+
+/// Re-attestation handle for an established aTLS connection.
+///
+/// Obtained from [`atls_connect_with_reattester`](crate::atls_connect_with_reattester).
+/// All methods take `&self`; the handle can be shared (e.g. behind an `Arc`)
+/// between the connection owner and whatever schedules re-attestation.
+///
+/// # Safe usage
+///
+/// [`reattest`](Self::reattest) writes a `POST /tdx_quote` request on the
+/// live stream and reads its response. The caller must guarantee the
+/// connection is quiescent (no application request or response in flight),
+/// otherwise the exchange would interleave with application traffic.
+///
+/// On failure the error is wrapped in
+/// [`AtlsVerificationError::Reattestation`] and the evidence age is *not*
+/// refreshed: treat the connection as unverified and stop using it
+/// (fail closed).
+//
+// NOTE: deliberately no `Debug` impl — the struct holds the session EKM,
+// which must never be logged.
+pub struct Reattester {
+    verifier: Verifier,
+    peer_cert: Vec<u8>,
+    session_ekm: Vec<u8>,
+    server_name: String,
+    interval_secs: u64,
+    /// UNIX seconds of the last successful verification.
+    verified_at_secs: AtomicU64,
+}
+
+impl Reattester {
+    /// Create a handle for a connection that was verified just now.
+    ///
+    /// The interval is read from the verifier's policy
+    /// (`reattestation_interval_secs`; 0 disables re-attestation).
+    pub(crate) fn new(
+        verifier: Verifier,
+        peer_cert: Vec<u8>,
+        session_ekm: Vec<u8>,
+        server_name: String,
+    ) -> Self {
+        let interval_secs = verifier.reattestation_interval_secs();
+        Self {
+            verifier,
+            peer_cert,
+            session_ekm,
+            server_name,
+            interval_secs,
+            verified_at_secs: AtomicU64::new(now_secs()),
+        }
+    }
+
+    /// The server name the connection was verified against.
+    pub fn server_name(&self) -> &str {
+        &self.server_name
+    }
+
+    /// Configured re-attestation interval in seconds (0 = disabled).
+    pub fn interval_secs(&self) -> u64 {
+        self.interval_secs
+    }
+
+    /// Age in seconds of the current attestation evidence.
+    pub fn evidence_age_secs(&self) -> u64 {
+        now_secs().saturating_sub(self.verified_at_secs.load(Ordering::Acquire))
+    }
+
+    /// Whether the attestation evidence is older than the configured
+    /// interval and the connection should be re-attested before further use.
+    ///
+    /// Always `false` when re-attestation is disabled (interval 0).
+    pub fn is_due(&self) -> bool {
+        due(self.evidence_age_secs(), self.interval_secs)
+    }
+
+    /// Re-attest the connection in-band over `stream`.
+    ///
+    /// Sends a `POST /tdx_quote` request with a fresh nonce on the live
+    /// stream and runs the full verification pipeline on the response. The
+    /// stream must be quiescent (see the type-level docs). On success the
+    /// evidence age resets; on failure it does not and the connection must
+    /// not be used further.
+    pub async fn reattest<S>(&self, stream: &mut S) -> Result<Report, AtlsVerificationError>
+    where
+        S: AsyncByteStream,
+    {
+        let result = self
+            .verifier
+            .reverify(
+                stream,
+                &self.peer_cert,
+                &self.session_ekm,
+                &self.server_name,
+            )
+            .await;
+        self.finish_result(result)
+    }
+
+    /// Begin a re-attestation exchange over a caller-owned transport.
+    ///
+    /// Use this when the raw stream is not directly accessible (e.g. it is
+    /// owned by an HTTP client): send an HTTP request built from the
+    /// returned [`ReattestRequest`] to the attester, then pass the response
+    /// body to [`finish`](Self::finish).
+    pub fn begin(&self) -> ReattestRequest {
+        ReattestRequest {
+            nonce: rand::random(),
+        }
+    }
+
+    /// Finish a re-attestation exchange started with [`begin`](Self::begin).
+    ///
+    /// `response_body` is the raw body of the `/tdx_quote` HTTP response.
+    /// Runs the full verification pipeline; the response must prove
+    /// `report_data == SHA512(nonce || session_ekm)` for the nonce issued by
+    /// `begin`. Same success/failure semantics as [`reattest`](Self::reattest).
+    pub async fn finish(
+        &self,
+        request: &ReattestRequest,
+        response_body: &[u8],
+    ) -> Result<Report, AtlsVerificationError> {
+        let result = self
+            .verifier
+            .appraise_quote_body(
+                response_body,
+                &request.nonce,
+                &self.peer_cert,
+                &self.session_ekm,
+            )
+            .await;
+        self.finish_result(result)
+    }
+
+    /// Record success (refresh evidence age) or wrap failure.
+    fn finish_result(
+        &self,
+        result: Result<Report, AtlsVerificationError>,
+    ) -> Result<Report, AtlsVerificationError> {
+        match result {
+            Ok(report) => {
+                self.verified_at_secs.store(now_secs(), Ordering::Release);
+                Ok(report)
+            }
+            Err(source) => Err(AtlsVerificationError::Reattestation {
+                source: Box::new(source),
+            }),
+        }
+    }
+}
+
+/// A prepared re-attestation request for caller-owned transports.
+///
+/// Holds the fresh nonce (kept private so it cannot be tampered with between
+/// [`Reattester::begin`] and [`Reattester::finish`]) plus helpers describing
+/// the HTTP request to send to the attester.
+pub struct ReattestRequest {
+    nonce: [u8; 32],
+}
+
+impl ReattestRequest {
+    /// HTTP method of the quote endpoint.
+    pub fn method() -> &'static str {
+        "POST"
+    }
+
+    /// Path of the quote endpoint.
+    pub fn path() -> &'static str {
+        "/tdx_quote"
+    }
+
+    /// Content type of the request body.
+    pub fn content_type() -> &'static str {
+        "application/json"
+    }
+
+    /// JSON request body carrying the nonce.
+    pub fn body_json(&self) -> String {
+        serde_json::json!({ "nonce_hex": hex::encode(self.nonce) }).to_string()
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::dstack::DstackTdxPolicy;
+    use crate::policy::Policy;
+    use crate::verifier::IntoVerifier;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
+
+    fn test_reattester(interval_secs: u64) -> Reattester {
+        let mut policy = DstackTdxPolicy::dev();
+        policy.reattestation_interval_secs = interval_secs;
+        let verifier = Policy::DstackTdx(policy).into_verifier().unwrap();
+        Reattester::new(
+            verifier,
+            b"peer-cert-der".to_vec(),
+            vec![0u8; 32],
+            "tee.test".to_string(),
+        )
+    }
+
+    fn backdate(reattester: &Reattester, secs: u64) {
+        reattester
+            .verified_at_secs
+            .store(now_secs().saturating_sub(secs), Ordering::Release);
+    }
+
+    /// Read one HTTP request (headers + Content-Length body) from the stream.
+    async fn read_http_request(server: &mut DuplexStream) -> String {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 1024];
+        loop {
+            let n = server.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client closed while sending request");
+            buf.extend_from_slice(&chunk[..n]);
+
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                let headers = String::from_utf8_lossy(&buf[..pos]).to_string();
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.to_ascii_lowercase()
+                            .strip_prefix("content-length:")
+                            .map(|v| v.trim().parse::<usize>().unwrap())
+                    })
+                    .unwrap_or(0);
+                if buf.len() >= pos + 4 + content_length {
+                    return String::from_utf8(buf).unwrap();
+                }
+            }
+        }
+    }
+
+    fn quote_response_with_empty_event_log() -> String {
+        let body = serde_json::json!({
+            "quote": {
+                "quote": "",
+                "event_log": "[]",
+                "report_data": "",
+                "vm_config": ""
+            }
+        })
+        .to_string();
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+    }
+
+    fn extract_nonce_hex(request: &str) -> String {
+        let body = request.split("\r\n\r\n").nth(1).unwrap();
+        let json: serde_json::Value = serde_json::from_str(body).unwrap();
+        json["nonce_hex"].as_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn test_due_math() {
+        // 0 disables re-attestation regardless of age.
+        assert!(!due(0, 0));
+        assert!(!due(10_000, 0));
+        // Age thresholds.
+        assert!(!due(299, 300));
+        assert!(due(300, 300));
+        assert!(due(301, 300));
+    }
+
+    #[test]
+    fn test_is_due_lifecycle() {
+        let reattester = test_reattester(300);
+        assert!(!reattester.is_due(), "fresh evidence must not be due");
+        assert!(reattester.evidence_age_secs() <= 1);
+
+        backdate(&reattester, 400);
+        assert!(reattester.evidence_age_secs() >= 400);
+        assert!(reattester.is_due());
+
+        let disabled = test_reattester(0);
+        backdate(&disabled, 1_000_000);
+        assert!(!disabled.is_due(), "interval 0 must disable re-attestation");
+        assert_eq!(disabled.interval_secs(), 0);
+    }
+
+    #[test]
+    fn test_reattest_request_body_shape() {
+        let reattester = test_reattester(300);
+        let req1 = reattester.begin();
+        let req2 = reattester.begin();
+
+        let json: serde_json::Value = serde_json::from_str(&req1.body_json()).unwrap();
+        let nonce_hex = json["nonce_hex"].as_str().unwrap();
+        assert_eq!(nonce_hex.len(), 64);
+        assert!(nonce_hex.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Fresh nonce for every exchange.
+        assert_ne!(req1.body_json(), req2.body_json());
+
+        assert_eq!(ReattestRequest::method(), "POST");
+        assert_eq!(ReattestRequest::path(), "/tdx_quote");
+        assert_eq!(ReattestRequest::content_type(), "application/json");
+    }
+
+    #[tokio::test]
+    async fn test_reattest_request_framing_and_fail_closed_appraisal() {
+        let (mut client, mut server) = tokio::io::duplex(64 * 1024);
+        let reattester = test_reattester(300);
+
+        let server_task = tokio::spawn(async move {
+            let request = read_http_request(&mut server).await;
+            assert!(request.starts_with("POST /tdx_quote HTTP/1.1\r\n"));
+            assert!(request.contains("Host: tee.test\r\n"));
+            assert!(request.contains("Content-Type: application/json\r\n"));
+            let nonce_hex = extract_nonce_hex(&request);
+            assert_eq!(nonce_hex.len(), 64);
+
+            // Valid HTTP but an empty event log: appraisal must fail closed
+            // at the certificate check, before any network access. Deliver
+            // the response across many partial writes to exercise the
+            // client's read loop.
+            let response = quote_response_with_empty_event_log();
+            for chunk in response.as_bytes().chunks(17) {
+                server.write_all(chunk).await.unwrap();
+                server.flush().await.unwrap();
+            }
+            nonce_hex
+        });
+
+        let err = reattester.reattest(&mut client).await.unwrap_err();
+        match err {
+            AtlsVerificationError::Reattestation { source } => {
+                assert!(matches!(
+                    *source,
+                    AtlsVerificationError::CertificateNotInEventLog
+                ));
+            }
+            other => panic!("expected Reattestation error, got: {other}"),
+        }
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_reattest_uses_fresh_nonce_per_exchange() {
+        let (mut client, mut server) = tokio::io::duplex(64 * 1024);
+        let reattester = test_reattester(300);
+
+        let server_task = tokio::spawn(async move {
+            let mut nonces = Vec::new();
+            for _ in 0..2 {
+                let request = read_http_request(&mut server).await;
+                nonces.push(extract_nonce_hex(&request));
+                let response = quote_response_with_empty_event_log();
+                server.write_all(response.as_bytes()).await.unwrap();
+                server.flush().await.unwrap();
+            }
+            nonces
+        });
+
+        // Both exchanges fail appraisal (empty event log); we only care that
+        // each one sent a distinct nonce.
+        let _ = reattester.reattest(&mut client).await.unwrap_err();
+        let _ = reattester.reattest(&mut client).await.unwrap_err();
+
+        let nonces = server_task.await.unwrap();
+        assert_eq!(nonces.len(), 2);
+        assert_ne!(nonces[0], nonces[1], "nonce must be fresh per exchange");
+    }
+
+    #[tokio::test]
+    async fn test_reattest_failure_keeps_evidence_stale() {
+        let (mut client, mut server) = tokio::io::duplex(64 * 1024);
+        let reattester = test_reattester(300);
+        backdate(&reattester, 400);
+        assert!(reattester.is_due());
+
+        let server_task = tokio::spawn(async move {
+            let _request = read_http_request(&mut server).await;
+            // Close without responding: the client sees EOF mid-exchange.
+            drop(server);
+        });
+
+        let err = reattester.reattest(&mut client).await.unwrap_err();
+        match err {
+            AtlsVerificationError::Reattestation { source } => {
+                assert!(matches!(*source, AtlsVerificationError::Io(_)));
+            }
+            other => panic!("expected Reattestation error, got: {other}"),
+        }
+        assert!(
+            reattester.is_due(),
+            "failed re-attestation must not refresh the evidence age"
+        );
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_finish_rejects_invalid_response_body() {
+        let reattester = test_reattester(300);
+        let request = reattester.begin();
+
+        let err = reattester.finish(&request, b"not json").await.unwrap_err();
+        match err {
+            AtlsVerificationError::Reattestation { source } => {
+                assert!(matches!(*source, AtlsVerificationError::Quote(_)));
+            }
+            other => panic!("expected Reattestation error, got: {other}"),
+        }
+    }
+}

--- a/core/src/tdx/grace_period.rs
+++ b/core/src/tdx/grace_period.rs
@@ -3,8 +3,8 @@
 use chrono::DateTime;
 use dcap_qvl::intel::parse_pck_extension;
 use dcap_qvl::quote::Quote;
-use dcap_qvl::QuoteCollateralV3;
 use dcap_qvl::verify::VerifiedReport;
+use dcap_qvl::QuoteCollateralV3;
 use pem::parse_many;
 use serde::Deserialize;
 
@@ -40,13 +40,11 @@ fn evaluate_grace_period(
     now_secs: u64,
     grace: u64,
 ) -> Result<(), AtlsVerificationError> {
-    let now_secs = i64::try_from(now_secs).map_err(|_| {
-        AtlsVerificationError::TcbInfoError("current time out of range".into())
-    })?;
+    let now_secs = i64::try_from(now_secs)
+        .map_err(|_| AtlsVerificationError::TcbInfoError("current time out of range".into()))?;
 
-    let grace_secs = i64::try_from(grace).map_err(|_| {
-        AtlsVerificationError::Configuration("grace_period is too large".into())
-    })?;
+    let grace_secs = i64::try_from(grace)
+        .map_err(|_| AtlsVerificationError::Configuration("grace_period is too large".into()))?;
     let expiration = tcb_date_secs.checked_add(grace_secs).ok_or_else(|| {
         AtlsVerificationError::Configuration("grace_period causes timestamp overflow".into())
     })?;
@@ -136,9 +134,7 @@ fn extract_pck_leaf_cert(
     if let Some(pem_chain) = &collateral.pck_certificate_chain {
         let certs = parse_pem_chain(pem_chain)?;
         return certs.first().cloned().ok_or_else(|| {
-            AtlsVerificationError::TcbInfoError(
-                "PCK certificate chain is empty".to_string(),
-            )
+            AtlsVerificationError::TcbInfoError("PCK certificate chain is empty".to_string())
         });
     }
 
@@ -156,17 +152,17 @@ fn extract_pck_leaf_cert(
 
 fn parse_pem_chain(pem_chain: &str) -> Result<Vec<Vec<u8>>, AtlsVerificationError> {
     let certs = parse_many(pem_chain).map_err(|e| {
-        AtlsVerificationError::TcbInfoError(format!(
-            "failed to parse PCK certificate chain: {}",
-            e
-        ))
+        AtlsVerificationError::TcbInfoError(format!("failed to parse PCK certificate chain: {}", e))
     })?;
     if certs.is_empty() {
         return Err(AtlsVerificationError::TcbInfoError(
             "failed to parse PCK certificate chain".to_string(),
         ));
     }
-    Ok(certs.into_iter().map(|pem| pem.contents().to_vec()).collect())
+    Ok(certs
+        .into_iter()
+        .map(|pem| pem.contents().to_vec())
+        .collect())
 }
 
 fn match_tcb_level<'a>(
@@ -211,8 +207,7 @@ fn match_tcb_level<'a>(
             continue;
         }
 
-        let sgx_components: Vec<u8> =
-            tcb_level.tcb.sgx_components.iter().map(|c| c.svn).collect();
+        let sgx_components: Vec<u8> = tcb_level.tcb.sgx_components.iter().map(|c| c.svn).collect();
         if sgx_components.is_empty() {
             return Err(AtlsVerificationError::TcbInfoError(
                 "no SGX components in TCB info".into(),
@@ -256,13 +251,7 @@ mod tests {
 
     #[test]
     fn test_grace_period_expired() {
-        let result = evaluate_grace_period(
-            "OutOfDate",
-            100,
-            "2024-01-01T00:00:00Z",
-            200,
-            50,
-        );
+        let result = evaluate_grace_period("OutOfDate", 100, "2024-01-01T00:00:00Z", 200, 50);
 
         assert!(matches!(
             result,
@@ -272,26 +261,14 @@ mod tests {
 
     #[test]
     fn test_grace_period_allows_within_window() {
-        let result = evaluate_grace_period(
-            "OutOfDate",
-            100,
-            "2024-01-01T00:00:00Z",
-            120,
-            50,
-        );
+        let result = evaluate_grace_period("OutOfDate", 100, "2024-01-01T00:00:00Z", 120, 50);
 
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_grace_period_zero_expires_immediately() {
-        let result = evaluate_grace_period(
-            "OutOfDate",
-            100,
-            "2024-01-01T00:00:00Z",
-            101,
-            0,
-        );
+        let result = evaluate_grace_period("OutOfDate", 100, "2024-01-01T00:00:00Z", 101, 0);
 
         assert!(matches!(
             result,

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -18,3 +18,53 @@ pub(crate) fn now_secs() -> u64 {
 pub(crate) fn now_secs() -> u64 {
     (js_sys::Date::now() / 1000.0) as u64
 }
+
+/// Arbitrary offset added to the monotonic reading so timestamps before the
+/// clock's raw origin (which starts near zero at process/page start) remain
+/// representable — e.g. tests backdating attestation evidence.
+const MONO_EPOCH_OFFSET_MILLIS: u64 = 1 << 32;
+
+#[cfg(not(target_arch = "wasm32"))]
+static MONO_START: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+
+/// Milliseconds elapsed on a monotonic clock (arbitrary epoch).
+///
+/// Used for measuring elapsed time (e.g. attestation-evidence age), where a
+/// wall-clock step must not shrink the measured age. Native builds use
+/// `Instant`, which is immune to wall-clock adjustments.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn mono_millis() -> u64 {
+    MONO_EPOCH_OFFSET_MILLIS
+        + MONO_START
+            .get_or_init(std::time::Instant::now)
+            .elapsed()
+            .as_millis() as u64
+}
+
+/// Milliseconds elapsed on a monotonic clock (arbitrary epoch).
+///
+/// wasm builds use `performance.now()` (monotonic; available in both window
+/// and worker contexts). If no `performance` global exists, falls back to
+/// `Date.now()`, which is *not* monotonic — consumers must treat an apparent
+/// backwards step as maximal staleness (fail closed).
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn mono_millis() -> u64 {
+    use wasm_bindgen::{JsCast, JsValue};
+
+    let global = js_sys::global();
+    if let Ok(performance) = js_sys::Reflect::get(&global, &JsValue::from_str("performance")) {
+        if let Ok(now_fn) = js_sys::Reflect::get(&performance, &JsValue::from_str("now")) {
+            if let Some(now_fn) = now_fn.dyn_ref::<js_sys::Function>() {
+                if let Ok(value) = now_fn.call0(&performance) {
+                    if let Some(millis) = value.as_f64() {
+                        return MONO_EPOCH_OFFSET_MILLIS + millis as u64;
+                    }
+                }
+            }
+        }
+    }
+
+    // Date.now() is large enough on its own; the offset keeps the scale
+    // consistent across sources.
+    MONO_EPOCH_OFFSET_MILLIS + js_sys::Date::now() as u64
+}

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -1,0 +1,20 @@
+//! Platform-specific time helpers.
+
+/// Current UNIX time in whole seconds.
+///
+/// Native builds read the system clock; wasm builds use `js_sys::Date`.
+/// Returns 0 if the system clock is before the UNIX epoch (practically
+/// unreachable) — time-sensitive checks then fail closed.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Current UNIX time in whole seconds.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn now_secs() -> u64 {
+    (js_sys::Date::now() / 1000.0) as u64
+}

--- a/core/src/verifier.rs
+++ b/core/src/verifier.rs
@@ -156,6 +156,68 @@ pub enum Verifier {
     DstackTdx(crate::dstack::DstackTDXVerifier),
 }
 
+impl Verifier {
+    /// Configured re-attestation interval in seconds (0 = disabled).
+    pub fn reattestation_interval_secs(&self) -> u64 {
+        match self {
+            Verifier::DstackTdx(v) => v.reattestation_interval_secs(),
+        }
+    }
+
+    /// Re-verify an established session in-band over `stream`.
+    ///
+    /// Same pipeline as [`AtlsVerifier::verify`], but the session certificate
+    /// may match *any* certificate event in the log: the session cert stays
+    /// valid for the connection lifetime even if the attester has since
+    /// rotated to a new certificate (rotation appends a new event).
+    pub(crate) async fn reverify<S>(
+        &self,
+        stream: &mut S,
+        peer_cert: &[u8],
+        session_ekm: &[u8],
+        hostname: &str,
+    ) -> Result<Report, AtlsVerificationError>
+    where
+        S: AsyncByteStream,
+    {
+        match self {
+            Verifier::DstackTdx(v) => {
+                v.verify_with_mode(
+                    stream,
+                    peer_cert,
+                    session_ekm,
+                    hostname,
+                    crate::dstack::CertEventMatch::Any,
+                )
+                .await
+            }
+        }
+    }
+
+    /// Appraise a `/tdx_quote` response body fetched over a caller-owned
+    /// transport, using re-attestation certificate matching.
+    pub(crate) async fn appraise_quote_body(
+        &self,
+        body: &[u8],
+        nonce: &[u8; 32],
+        peer_cert: &[u8],
+        session_ekm: &[u8],
+    ) -> Result<Report, AtlsVerificationError> {
+        match self {
+            Verifier::DstackTdx(v) => {
+                v.appraise_quote_body(
+                    body,
+                    nonce,
+                    peer_cert,
+                    session_ekm,
+                    crate::dstack::CertEventMatch::Any,
+                )
+                .await
+            }
+        }
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 impl AtlsVerifier for Verifier {
     fn verify<S>(

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -3,7 +3,8 @@
 //! These tests verify real TDX attestation against a live dstack deployment.
 
 use atlas_rs::{
-    DstackTDXVerifierBuilder, ExpectedBootchain, AtlsVerificationError, dstack::{compose_hash::get_compose_hash, get_default_app_compose}
+    dstack::{compose_hash::get_compose_hash, get_default_app_compose},
+    AtlsVerificationError, DstackTDXVerifierBuilder, ExpectedBootchain,
 };
 use serde_json::json;
 
@@ -13,8 +14,7 @@ const TEST_HOST: &str = "vllm.concrete-security.com";
 /// OS image hash for testing.
 /// This is the hash observed in production for vllm.concrete-security.com
 /// and should be updated if the OS image changes.
-const TEST_OS_IMAGE_HASH: &str =
-    "86b181377635db21c415f9ece8cc8505f7d4936ad3be7043969005a8c4690c1a";
+const TEST_OS_IMAGE_HASH: &str = "86b181377635db21c415f9ece8cc8505f7d4936ad3be7043969005a8c4690c1a";
 
 /// Bootchain measurements for testing (Dstack 0.5.4.1-nvidia).
 fn test_bootchain() -> ExpectedBootchain {
@@ -92,7 +92,10 @@ fn test_builder_complete_config() {
         .app_compose(app_compose)
         .expected_bootchain(test_bootchain())
         .os_image_hash(TEST_OS_IMAGE_HASH)
-        .allowed_tcb_status(vec!["UpToDate".to_string(), "SWHardeningNeeded".to_string()])
+        .allowed_tcb_status(vec![
+            "UpToDate".to_string(),
+            "SWHardeningNeeded".to_string(),
+        ])
         .cache_collateral(true)
         .build();
 
@@ -118,15 +121,15 @@ fn test_expected_bootchain_values() {
 
 mod integration {
     use super::*;
+    use atlas_rs::tdx::grace_period::enforce_grace_period;
     use atlas_rs::AtlsVerifier;
     use atlas_rs::{DstackTdxPolicy, Policy};
-    use atlas_rs::tdx::grace_period::enforce_grace_period;
     use dcap_qvl::collateral::get_collateral;
     use dcap_qvl::quote::Quote;
     use dcap_qvl::verify::verify;
     use dstack_sdk_types::dstack::GetQuoteResponse;
-    use rustls::pki_types::ServerName;
     use rustls::crypto::ring::default_provider;
+    use rustls::pki_types::ServerName;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::net::TcpStream;
@@ -141,7 +144,10 @@ mod integration {
     /// Establish an async TLS connection and return the stream, peer certificate, and session EKM.
     async fn connect_tls(
         host: &str,
-    ) -> Result<(tokio_rustls::client::TlsStream<TcpStream>, Vec<u8>, Vec<u8>), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<
+        (tokio_rustls::client::TlsStream<TcpStream>, Vec<u8>, Vec<u8>),
+        Box<dyn std::error::Error + Send + Sync>,
+    > {
         // Ensure crypto provider is installed
         ensure_crypto_provider();
 
@@ -160,7 +166,9 @@ mod integration {
         let tcp_stream = TcpStream::connect(format!("{}:443", host)).await?;
 
         // Complete TLS handshake
-        let stream = connector.connect(server_name.to_owned(), tcp_stream).await?;
+        let stream = connector
+            .connect(server_name.to_owned(), tcp_stream)
+            .await?;
 
         // Get peer certificate and extract session EKM
         let (_, conn) = stream.get_ref();
@@ -217,15 +225,14 @@ mod integration {
             .build()
             .expect("Failed to build verifier");
 
-        let (mut stream, peer_cert, session_ekm) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
+        let (mut stream, peer_cert, session_ekm) =
+            connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
 
-        let result = verifier.verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST).await;
+        let result = verifier
+            .verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST)
+            .await;
 
-        assert!(
-            result.is_ok(),
-            "Verification failed: {:?}",
-            result.err()
-        );
+        assert!(result.is_ok(), "Verification failed: {:?}", result.err());
         let report = result.unwrap();
         match &report {
             atlas_rs::Report::Tdx(tdx_report) => {
@@ -246,10 +253,7 @@ mod integration {
 
         let policy = Policy::DstackTdx(DstackTdxPolicy {
             grace_period: Some(0),
-            allowed_tcb_status: vec![
-                "UpToDate".to_string(),
-                "OutOfDate".to_string(),
-            ],
+            allowed_tcb_status: vec!["UpToDate".to_string(), "OutOfDate".to_string()],
             disable_runtime_verification: true,
             ..Default::default()
         });
@@ -277,48 +281,60 @@ mod integration {
             .expect("Failed to decode quote");
         let quote = Quote::parse(&quote_bytes).expect("Failed to parse quote");
 
-        let collateral = get_collateral(
-            atlas_rs::dstack::policy::DEFAULT_PCCS_URL,
-            &quote_bytes,
-        )
-        .await
-        .expect("Failed to fetch collateral");
+        let collateral = get_collateral(atlas_rs::dstack::policy::DEFAULT_PCCS_URL, &quote_bytes)
+            .await
+            .expect("Failed to fetch collateral");
 
         let now_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards")
             .as_secs();
 
-        let report = verify(&quote_bytes, &collateral, now_secs)
-            .expect("DCAP verification failed");
+        let report = verify(&quote_bytes, &collateral, now_secs).expect("DCAP verification failed");
 
         if report.status == "OutOfDate" {
             // Platform is actually OutOfDate — test both paths.
 
             // Valid window: use a time before the TCB date to guarantee success.
             let valid = enforce_grace_period(&report, &quote, &collateral, Some(0), 0);
-            assert!(valid.is_ok(), "Expected grace period to be valid, got: {:?}", valid);
+            assert!(
+                valid.is_ok(),
+                "Expected grace period to be valid, got: {:?}",
+                valid
+            );
             // Same as above but with a non-zero grace period
-            let valid = enforce_grace_period(&report, &quote, &collateral, Some(60*60*24), 0);
-            assert!(valid.is_ok(), "Expected grace period to be valid, got: {:?}", valid);
+            let valid = enforce_grace_period(&report, &quote, &collateral, Some(60 * 60 * 24), 0);
+            assert!(
+                valid.is_ok(),
+                "Expected grace period to be valid, got: {:?}",
+                valid
+            );
 
             // Expired window: use a far-future time to guarantee expiration.
             let expired = enforce_grace_period(
                 &report,
                 &quote,
                 &collateral,
-                Some(3600 * 24 * 30), // 30 days grace period
+                Some(3600 * 24 * 30),   // 30 days grace period
                 (i64::MAX / 16) as u64, // div 16 to avoid overflow
             );
             assert!(
-                matches!(expired, Err(AtlsVerificationError::GracePeriodExpired { .. })),
+                matches!(
+                    expired,
+                    Err(AtlsVerificationError::GracePeriodExpired { .. })
+                ),
                 "Expected GracePeriodExpired, got: {:?}",
                 expired
             );
         } else {
             // Platform is not OutOfDate — grace period is a no-op regardless of config.
             let result = enforce_grace_period(&report, &quote, &collateral, Some(0), 0);
-            assert!(result.is_ok(), "Grace period should be no-op for status '{}', got: {:?}", report.status, result);
+            assert!(
+                result.is_ok(),
+                "Grace period should be no-op for status '{}', got: {:?}",
+                report.status,
+                result
+            );
         }
     }
 
@@ -344,20 +360,24 @@ mod integration {
             .build()
             .expect("Failed to build verifier");
 
-        let (mut stream, peer_cert, session_ekm) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
+        let (mut stream, peer_cert, session_ekm) =
+            connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
 
-        let result = verifier.verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST).await;
+        let result = verifier
+            .verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST)
+            .await;
 
         // This might fail if app_compose doesn't match - that's expected
         // The important thing is that the verifier runs the full verification
         match &result {
-            Ok(report) => {
-                match report {
-                    atlas_rs::Report::Tdx(tdx_report) => {
-                        println!("Full verification passed! TCB Status: {}", tdx_report.status);
-                    }
+            Ok(report) => match report {
+                atlas_rs::Report::Tdx(tdx_report) => {
+                    println!(
+                        "Full verification passed! TCB Status: {}",
+                        tdx_report.status
+                    );
                 }
-            }
+            },
             Err(e) => {
                 panic!("Unexpected verification error: {:?}", e);
             }
@@ -389,9 +409,12 @@ mod integration {
             .build()
             .expect("Failed to build verifier");
 
-        let (mut stream, peer_cert, session_ekm) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
+        let (mut stream, peer_cert, session_ekm) =
+            connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
 
-        let result = verifier.verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST).await;
+        let result = verifier
+            .verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST)
+            .await;
 
         assert!(
             matches!(result, Err(AtlsVerificationError::BootchainMismatch { .. })),
@@ -425,9 +448,12 @@ mod integration {
             .build()
             .expect("Failed to build verifier");
 
-        let (mut stream, peer_cert, session_ekm) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
+        let (mut stream, peer_cert, session_ekm) =
+            connect_tls(TEST_HOST).await.expect("Failed to connect TLS");
 
-        let result = verifier.verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST).await;
+        let result = verifier
+            .verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST)
+            .await;
 
         // The verifier should fail with either AppComposeHashMismatch (if compose doesn't match)
         // or OsImageHashMismatch (if compose matches but OS hash doesn't)
@@ -459,14 +485,30 @@ mod integration {
             .expect("Failed to build verifier");
 
         // First verification
-        let (mut stream1, peer_cert1, session_ekm1) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS (1)");
-        let result1 = verifier.verify(&mut stream1, &peer_cert1, &session_ekm1, TEST_HOST).await;
-        assert!(result1.is_ok(), "First verification failed: {:?}", result1.err());
+        let (mut stream1, peer_cert1, session_ekm1) = connect_tls(TEST_HOST)
+            .await
+            .expect("Failed to connect TLS (1)");
+        let result1 = verifier
+            .verify(&mut stream1, &peer_cert1, &session_ekm1, TEST_HOST)
+            .await;
+        assert!(
+            result1.is_ok(),
+            "First verification failed: {:?}",
+            result1.err()
+        );
 
         // Second verification (should use cached collateral)
-        let (mut stream2, peer_cert2, session_ekm2) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS (2)");
-        let result2 = verifier.verify(&mut stream2, &peer_cert2, &session_ekm2, TEST_HOST).await;
-        assert!(result2.is_ok(), "Second verification failed: {:?}", result2.err());
+        let (mut stream2, peer_cert2, session_ekm2) = connect_tls(TEST_HOST)
+            .await
+            .expect("Failed to connect TLS (2)");
+        let result2 = verifier
+            .verify(&mut stream2, &peer_cert2, &session_ekm2, TEST_HOST)
+            .await;
+        assert!(
+            result2.is_ok(),
+            "Second verification failed: {:?}",
+            result2.err()
+        );
 
         println!("Multiple verifications with same verifier instance passed!");
     }
@@ -486,14 +528,30 @@ mod integration {
             .expect("Failed to build verifier");
 
         // First verification - fetches collateral from PCCS
-        let (mut stream1, peer_cert1, session_ekm1) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS (1)");
-        let result1 = verifier.verify(&mut stream1, &peer_cert1, &session_ekm1, TEST_HOST).await;
-        assert!(result1.is_ok(), "First verification failed: {:?}", result1.err());
+        let (mut stream1, peer_cert1, session_ekm1) = connect_tls(TEST_HOST)
+            .await
+            .expect("Failed to connect TLS (1)");
+        let result1 = verifier
+            .verify(&mut stream1, &peer_cert1, &session_ekm1, TEST_HOST)
+            .await;
+        assert!(
+            result1.is_ok(),
+            "First verification failed: {:?}",
+            result1.err()
+        );
 
         // Second verification - uses cached collateral
-        let (mut stream2, peer_cert2, session_ekm2) = connect_tls(TEST_HOST).await.expect("Failed to connect TLS (2)");
-        let result2 = verifier.verify(&mut stream2, &peer_cert2, &session_ekm2, TEST_HOST).await;
-        assert!(result2.is_ok(), "Second verification (cached) failed: {:?}", result2.err());
+        let (mut stream2, peer_cert2, session_ekm2) = connect_tls(TEST_HOST)
+            .await
+            .expect("Failed to connect TLS (2)");
+        let result2 = verifier
+            .verify(&mut stream2, &peer_cert2, &session_ekm2, TEST_HOST)
+            .await;
+        assert!(
+            result2.is_ok(),
+            "Second verification (cached) failed: {:?}",
+            result2.err()
+        );
 
         println!("Collateral caching test passed!");
     }
@@ -521,7 +579,9 @@ mod integration {
         // Run the async verification using block_on
         let result = rt.block_on(async {
             let (mut stream, peer_cert, session_ekm) = connect_tls(TEST_HOST).await?;
-            verifier.verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST).await
+            verifier
+                .verify(&mut stream, &peer_cert, &session_ekm, TEST_HOST)
+                .await
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
         });
 
@@ -550,10 +610,7 @@ mod integration {
             expected_bootchain: Some(test_bootchain()),
             app_compose: Some(app_compose),
             os_image_hash: Some(TEST_OS_IMAGE_HASH.to_string()),
-            allowed_tcb_status: vec![
-                "UpToDate".to_string(),
-                "SWHardeningNeeded".to_string(),
-            ],
+            allowed_tcb_status: vec!["UpToDate".to_string(), "SWHardeningNeeded".to_string()],
             ..Default::default()
         });
         let result = atlas_rs::atls_connect(tcp, TEST_HOST, policy, None).await;
@@ -561,17 +618,59 @@ mod integration {
         // This might fail if app_compose doesn't match - that's expected
         // The important thing is that the verifier runs the full verification
         match &result {
-            Ok((_, report)) => {
-                match report {
-                    atlas_rs::Report::Tdx(tdx_report) => {
-                        println!("atls_connect full verification passed! TCB Status: {}", tdx_report.status);
-                    }
+            Ok((_, report)) => match report {
+                atlas_rs::Report::Tdx(tdx_report) => {
+                    println!(
+                        "atls_connect full verification passed! TCB Status: {}",
+                        tdx_report.status
+                    );
                 }
-            }
+            },
             Err(e) => {
                 panic!("Unexpected verification error: {:?}", e);
             }
         }
+    }
+
+    /// Test in-band re-attestation of a live connection: connect with the
+    /// minimum interval, wait until the evidence is due, then re-attest over
+    /// the same TLS session (fresh nonce, same EKM).
+    #[tokio::test]
+    #[ignore = "live enclave vllm.concrete-security.com decommissioned; needs offline fixtures or a new endpoint"]
+    async fn test_reattest_live_connection() {
+        let tcp = tokio::net::TcpStream::connect(format!("{}:443", TEST_HOST))
+            .await
+            .expect("Failed to connect TCP");
+
+        let policy = atlas_rs::Policy::DstackTdx(atlas_rs::DstackTdxPolicy {
+            reattestation_interval_secs: 30,
+            cache_collateral: true,
+            ..DstackTdxPolicy::dev()
+        });
+        let (mut stream, _report, reattester) =
+            atlas_rs::atls_connect_with_reattester(tcp, TEST_HOST, policy, None)
+                .await
+                .expect("aTLS connect failed");
+
+        assert!(!reattester.is_due(), "evidence must be fresh after connect");
+
+        // Wait past the interval; the connection is idle, so re-attesting is safe.
+        tokio::time::sleep(std::time::Duration::from_secs(31)).await;
+        assert!(reattester.is_due());
+
+        let report = reattester
+            .reattest(&mut stream)
+            .await
+            .expect("re-attestation over the live session failed");
+        match report {
+            atlas_rs::Report::Tdx(tdx_report) => {
+                println!("Re-attestation passed! TCB Status: {}", tdx_report.status);
+            }
+        }
+        assert!(
+            !reattester.is_due(),
+            "evidence age must reset after successful re-attestation"
+        );
     }
 
     /// Test atls_connect with ALPN protocols and full verification.
@@ -590,28 +689,22 @@ mod integration {
             expected_bootchain: Some(test_bootchain()),
             app_compose: Some(app_compose),
             os_image_hash: Some(TEST_OS_IMAGE_HASH.to_string()),
-            allowed_tcb_status: vec![
-                "UpToDate".to_string(),
-                "SWHardeningNeeded".to_string(),
-            ],
+            allowed_tcb_status: vec!["UpToDate".to_string(), "SWHardeningNeeded".to_string()],
             ..Default::default()
         });
-        let result = atlas_rs::atls_connect(
-            tcp,
-            TEST_HOST,
-            policy,
-            Some(vec!["http/1.1".into()]),
-        ).await;
+        let result =
+            atlas_rs::atls_connect(tcp, TEST_HOST, policy, Some(vec!["http/1.1".into()])).await;
 
         // This might fail if app_compose doesn't match - that's expected
         match &result {
-            Ok((_, report)) => {
-                match report {
-                    atlas_rs::Report::Tdx(tdx_report) => {
-                        println!("atls_connect with ALPN passed! TCB Status: {}", tdx_report.status);
-                    }
+            Ok((_, report)) => match report {
+                atlas_rs::Report::Tdx(tdx_report) => {
+                    println!(
+                        "atls_connect with ALPN passed! TCB Status: {}",
+                        tdx_report.status
+                    );
                 }
-            }
+            },
             Err(e) => {
                 panic!("Unexpected verification error: {:?}", e);
             }
@@ -628,15 +721,18 @@ mod integration {
 
         let result = atlas_rs::connect::tls_handshake(tcp, TEST_HOST, None).await;
 
-        assert!(
-            result.is_ok(),
-            "tls_handshake failed: {:?}",
-            result.err()
-        );
+        assert!(result.is_ok(), "tls_handshake failed: {:?}", result.err());
 
         let (_, peer_cert, session_ekm) = result.unwrap();
-        assert!(!peer_cert.is_empty(), "Peer certificate should not be empty");
+        assert!(
+            !peer_cert.is_empty(),
+            "Peer certificate should not be empty"
+        );
         assert_eq!(session_ekm.len(), 32, "Session EKM should be 32 bytes");
-        println!("tls_handshake passed! Cert size: {} bytes, EKM: {} bytes", peer_cert.len(), session_ekm.len());
+        println!(
+            "tls_handshake passed! Cert size: {} bytes, EKM: {} bytes",
+            peer_cert.len(),
+            session_ekm.len()
+        );
     }
 }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 atlas-rs = { path = "../core" }
 napi = { version = "2.16", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
 napi-derive = { version = "2.16", features = ["type-def"] }
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "net", "io-util"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "net", "io-util", "time"] }
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/node/README.md
+++ b/node/README.md
@@ -190,6 +190,23 @@ const fetch = createAtlsFetch({
 })
 ```
 
+### Periodic Re-attestation
+
+Connections are transparently re-attested while they stay in use, controlled
+by the policy's `reattestation_interval_secs` (default `300`; set `0` to
+disable completely, non-zero values below `30` are rejected):
+
+- **Bun**: reused pooled connections re-run the `/tdx_quote` exchange in-band
+  when their evidence is older than the interval, before the request is sent.
+- **Node**: pooled `https.Agent` sockets with expired evidence are retired and
+  the next request reconnects, which performs a full fresh attestation.
+
+Either way, no request is dispatched on a connection whose attestation
+evidence is older than the interval. Failures are fail-closed: the connection
+is destroyed and a fresh, fully attested one replaces it. `onAttestation`
+fires again on every re-attestation or reconnect, and `response.attestation`
+always reflects the evidence backing that request.
+
 For complete policy field descriptions, verification flow, and computing bootchain measurements, see:
 - [core/README.md#policy-configuration](../core/README.md#policy-configuration)
 - [core/BOOTCHAIN-VERIFICATION.md](../core/BOOTCHAIN-VERIFICATION.md)
@@ -241,6 +258,9 @@ Node.js bindings connect directly to TEE endpoints via TCP (no proxy required):
 2. **Quote Retrieval** - Fetches attestation quote from the server
 3. **Verification** - Validates quote against policy using Intel DCAP
 4. **Request Execution** - Proceeds with HTTP request over verified channel
+5. **Re-attestation** - Long-lived connections are re-verified whenever their
+   evidence is older than `reattestation_interval_secs` (see "Periodic
+   Re-attestation")
 
 All verification happens automatically. The attestation result is exposed on every response for audit logging or policy enforcement.
 

--- a/node/atls-fetch.d.ts
+++ b/node/atls-fetch.d.ts
@@ -48,6 +48,12 @@ export interface DstackTdxPolicy {
   app_compose?: AppCompose
   /** Allowed TCB status values (default: ["UpToDate"]) */
   allowed_tcb_status?: string[]
+  /**
+   * Max age (seconds) of attestation evidence before transparent
+   * re-attestation of the connection. Default: 300. Set to 0 to disable
+   * re-attestation completely; non-zero values below 30 are rejected.
+   */
+  reattestation_interval_secs?: number
   /** PCCS URL for collateral fetching */
   pccs_url?: string
   /** Cache collateral to avoid repeated fetches */

--- a/node/atls-fetch.js
+++ b/node/atls-fetch.js
@@ -270,22 +270,33 @@ function armEvidenceExpiry(socket, intervalSecs) {
   socket.atlsIdle = false
   if (socket.atlsExpiresAt === Infinity) return
 
-  const delay = socket.atlsExpiresAt - socket.atlsVerifiedAt
-  if (delay > MAX_TIMEOUT_MS) return
-
-  const timer = setTimeout(() => {
-    if (socket.atlsIdle) {
-      debug("agent:destroy-idle-expired", { expiresAt: socket.atlsExpiresAt })
-      socket.destroy()
+  // Chain timers for expiries beyond Node's setTimeout clamp (2^31 - 1 ms):
+  // a single oversized setTimeout would fire after ~1 ms instead of waiting.
+  let timer = null
+  const arm = () => {
+    const remaining = socket.atlsExpiresAt - Date.now()
+    if (remaining > MAX_TIMEOUT_MS) {
+      timer = setTimeout(arm, MAX_TIMEOUT_MS)
     } else {
-      // Busy with an in-flight response; keepSocketAlive() retires it when
-      // the response completes.
-      socket.atlsExpired = true
+      timer = setTimeout(() => {
+        if (socket.atlsIdle) {
+          debug("agent:destroy-idle-expired", { expiresAt: socket.atlsExpiresAt })
+          socket.destroy()
+        } else {
+          // Busy with an in-flight response; keepSocketAlive() retires it when
+          // the response completes.
+          socket.atlsExpired = true
+        }
+      }, Math.max(remaining, 0))
     }
-  }, delay)
-  timer.unref?.()
+    timer.unref?.()
+  }
+  arm()
   socket.once("close", () => clearTimeout(timer))
 }
+
+/** Error code used when a request is denied because the pooled socket's attestation evidence expired. */
+const ATLS_EVIDENCE_EXPIRED = "ATLS_EVIDENCE_EXPIRED"
 
 /** Whether an agent socket's attestation evidence has expired. */
 function atlsEvidenceExpired(socket) {
@@ -381,6 +392,22 @@ export function createAtlsAgent(options) {
     }
 
     reuseSocket(socket, req) {
+      if (atlsEvidenceExpired(socket)) {
+        // Fail closed: never dispatch a request on expired evidence. This
+        // covers sockets that expired while idle in the pool (between the
+        // unref'd timer firing and reuse, or if the process was suspended).
+        // The denied request carries a tagged error; createAtlsFetch retries
+        // it once on a fresh, fully attested connection.
+        debug("agent:deny-expired-reuse", { expiresAt: socket.atlsExpiresAt })
+        socket.atlsExpired = true
+        const err = new Error(
+          "aTLS attestation evidence expired; reconnect required"
+        )
+        err.code = ATLS_EVIDENCE_EXPIRED
+        socket.destroy()
+        req.destroy(err)
+        return
+      }
       socket.atlsIdle = false
       super.reuseSocket(socket, req)
     }
@@ -894,7 +921,7 @@ function createAtlsFetchNode(options) {
       contentLength,
     })
 
-    return new Promise((resolve, reject) => {
+    const attempt = (isRetry) => new Promise((resolve, reject) => {
       const reqOptions = {
         hostname: parsed.host,
         port: parseInt(parsed.port),
@@ -926,7 +953,23 @@ function createAtlsFetchNode(options) {
         resolve(response)
       })
 
-      req.on("error", reject)
+      req.on("error", (err) => {
+        // A pooled socket was denied at dispatch because its attestation
+        // evidence expired: transparently retry once — the expired socket is
+        // gone, so the retry opens a fresh, fully attested connection.
+        // Stream/iterable bodies cannot be replayed, so those surface the
+        // error instead.
+        if (
+          !isRetry &&
+          err?.code === ATLS_EVIDENCE_EXPIRED &&
+          (!body || kind === "buffer")
+        ) {
+          debug("fetch:retry-expired-evidence")
+          resolve(attempt(true))
+          return
+        }
+        reject(err)
+      })
 
       if (init.signal) {
         if (init.signal.aborted) {
@@ -978,6 +1021,8 @@ function createAtlsFetchNode(options) {
           req.end()
       }
     })
+
+    return attempt(false)
   }
 }
 

--- a/node/atls-fetch.js
+++ b/node/atls-fetch.js
@@ -73,6 +73,7 @@ const {
   socketWrite,
   socketClose,
   socketDestroy,
+  socketReattestIfDue,
   mergeWithDefaultAppCompose,
 } = require("./index.cjs")
 
@@ -249,8 +250,55 @@ function createAtlsDuplex(socketId, attestation, meta) {
   return duplex
 }
 
+// Node's setTimeout treats delays above 2^31-1 ms as 1 ms; skip the timer for
+// such far-out expiries (keepSocketAlive still checks the wall clock).
+const MAX_TIMEOUT_MS = 0x7fffffff
+
+/**
+ * Stamp attestation-evidence expiry bookkeeping on an agent socket and arm an
+ * unref'd timer that retires it if it expires while idle in the pool.
+ *
+ * The https.Agent path cannot re-attest in-band: Node's HTTP machinery keeps
+ * a read pending on pooled sockets, which would swallow the quote response.
+ * Expired sockets are retired instead — the next request transparently opens
+ * a fresh connection, which performs a full fresh attestation.
+ */
+function armEvidenceExpiry(socket, intervalSecs) {
+  socket.atlsVerifiedAt = Date.now()
+  socket.atlsExpiresAt =
+    intervalSecs > 0 ? socket.atlsVerifiedAt + intervalSecs * 1000 : Infinity
+  socket.atlsIdle = false
+  if (socket.atlsExpiresAt === Infinity) return
+
+  const delay = socket.atlsExpiresAt - socket.atlsVerifiedAt
+  if (delay > MAX_TIMEOUT_MS) return
+
+  const timer = setTimeout(() => {
+    if (socket.atlsIdle) {
+      debug("agent:destroy-idle-expired", { expiresAt: socket.atlsExpiresAt })
+      socket.destroy()
+    } else {
+      // Busy with an in-flight response; keepSocketAlive() retires it when
+      // the response completes.
+      socket.atlsExpired = true
+    }
+  }, delay)
+  timer.unref?.()
+  socket.once("close", () => clearTimeout(timer))
+}
+
+/** Whether an agent socket's attestation evidence has expired. */
+function atlsEvidenceExpired(socket) {
+  return socket.atlsExpired === true || Date.now() >= (socket.atlsExpiresAt ?? Infinity)
+}
+
 /**
  * Create an https.Agent that establishes aTLS connections
+ *
+ * Attestation evidence expires after the policy's
+ * `reattestation_interval_secs` (default 300; 0 disables): expired sockets
+ * are never reused and the next request reconnects with a fresh, fully
+ * attested connection. `onAttestation` fires again for each new connection.
  *
  * @param {AtlsAgentOptions} options - Options object with target and policy
  * @returns {Agent} An https.Agent that uses aTLS sockets
@@ -302,8 +350,9 @@ export function createAtlsAgent(options) {
   class AtlsAgent extends Agent {
     createConnection(connectOptions, callback) {
       atlsConnect(parsed.hostPort, effectiveServerName, policy)
-        .then(({ socketId, attestation }) => {
+        .then(({ socketId, attestation, reattestationIntervalSecs }) => {
           const socket = createAtlsDuplex(socketId, attestation, parsed)
+          armEvidenceExpiry(socket, reattestationIntervalSecs)
 
           // Call user's attestation callback before returning socket
           if (onAttestation) {
@@ -318,6 +367,22 @@ export function createAtlsAgent(options) {
           callback(null, socket)
         })
         .catch(callback)
+    }
+
+    keepSocketAlive(socket) {
+      socket.atlsIdle = true
+      if (atlsEvidenceExpired(socket)) {
+        // Retire instead of pooling: the next request reconnects, which
+        // performs a full fresh attestation (fail closed by construction).
+        debug("agent:retire-expired", { expiresAt: socket.atlsExpiresAt })
+        return false
+      }
+      return super.keepSocketAlive(socket)
+    }
+
+    reuseSocket(socket, req) {
+      socket.atlsIdle = false
+      super.reuseSocket(socket, req)
     }
   }
 
@@ -337,12 +402,26 @@ const MAX_HEADER_SIZE = 64 * 1024
 /**
  * Connection pool (single cached connection + overflow).
  * Avoids repeating the expensive aTLS handshake on every request.
+ *
+ * Reused connections are transparently re-attested in-band when their
+ * attestation evidence is older than the policy's
+ * `reattestation_interval_secs` (a released connection is quiescent, so the
+ * quote exchange cannot interleave with request traffic). On re-attestation
+ * failure the connection is destroyed and a fresh one — fully attested — is
+ * opened instead (fail closed).
+ *
+ * `deps` is a test seam: production callers omit it.
  */
-function createConnectionPool(parsed, serverName, policy, onAttestation) {
+function createConnectionPool(parsed, serverName, policy, onAttestation, deps = {}) {
+  const {
+    atlsConnect: connectFn = atlsConnect,
+    socketReattestIfDue: reattestFn = socketReattestIfDue,
+    socketDestroy: destroyFn = socketDestroy,
+  } = deps
   let cached = null // { socketId, busy, lastUsed, attestation }
 
   async function connect() {
-    const { socketId, attestation } = await atlsConnect(
+    const { socketId, attestation } = await connectFn(
       parsed.hostPort,
       serverName,
       policy,
@@ -361,7 +440,24 @@ function createConnectionPool(parsed, serverName, policy, onAttestation) {
       ) {
         debug("pool:reuse", { socketId: cached.socketId })
         cached.busy = true
-        return cached
+        try {
+          const attestation = await reattestFn(cached.socketId)
+          if (attestation) {
+            debug("pool:reattested", { socketId: cached.socketId })
+            cached.attestation = attestation
+            if (onAttestation) onAttestation(attestation)
+          }
+          return cached
+        } catch (err) {
+          // Fail closed: drop the connection and fall through to a fresh
+          // connect below, which performs a full attestation.
+          debug("pool:reattest-failed", {
+            socketId: cached.socketId,
+            err: err?.message,
+          })
+          try { destroyFn(cached.socketId) } catch (_) {}
+          cached = null
+        }
       }
       // Busy → open overflow connection (don't touch cached)
       if (cached && cached.busy) {
@@ -371,7 +467,7 @@ function createConnectionPool(parsed, serverName, policy, onAttestation) {
       // Stale or missing — (re)connect
       if (cached) {
         debug("pool:stale", { socketId: cached.socketId })
-        try { socketDestroy(cached.socketId) } catch (_) {}
+        try { destroyFn(cached.socketId) } catch (_) {}
         cached = null
       }
       cached = await connect()
@@ -386,13 +482,13 @@ function createConnectionPool(parsed, serverName, policy, onAttestation) {
       } else {
         // overflow connection — close it
         debug("pool:release:overflow", { socketId })
-        try { socketDestroy(socketId) } catch (_) {}
+        try { destroyFn(socketId) } catch (_) {}
       }
     },
 
     invalidate(socketId) {
       debug("pool:invalidate", { socketId })
-      try { socketDestroy(socketId) } catch (_) {}
+      try { destroyFn(socketId) } catch (_) {}
       if (cached && cached.socketId === socketId) cached = null
     },
   }
@@ -1050,5 +1146,8 @@ function normalizeBody(body) {
 
 // Re-export merge utility for users to construct app_compose
 export { mergeWithDefaultAppCompose }
+
+// Internal seams exposed for offline tests only — not part of the public API.
+export const _internals = { createConnectionPool, armEvidenceExpiry, atlsEvidenceExpired }
 
 export default createAtlsAgent

--- a/node/index.cjs
+++ b/node/index.cjs
@@ -310,10 +310,11 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { mergeWithDefaultAppCompose, atlsConnect, socketRead, socketWrite, socketClose, socketDestroy, closeAllSockets } = nativeBinding
+const { mergeWithDefaultAppCompose, atlsConnect, socketReattestIfDue, socketRead, socketWrite, socketClose, socketDestroy, closeAllSockets } = nativeBinding
 
 module.exports.mergeWithDefaultAppCompose = mergeWithDefaultAppCompose
 module.exports.atlsConnect = atlsConnect
+module.exports.socketReattestIfDue = socketReattestIfDue
 module.exports.socketRead = socketRead
 module.exports.socketWrite = socketWrite
 module.exports.socketClose = socketClose

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -13,6 +13,11 @@ export interface JsAttestation {
 export interface JsAtlsConnection {
   socketId: number
   attestation: JsAttestation
+  /**
+   * Max age (seconds) of attestation evidence before transparent
+   * re-attestation, from the policy. 0 means re-attestation is disabled.
+   */
+  reattestationIntervalSecs: number
 }
 /**
  * Merge a user-provided app_compose with default values.
@@ -24,6 +29,21 @@ export interface JsAtlsConnection {
 export declare function mergeWithDefaultAppCompose(userCompose: any): any
 /** Establish an aTLS connection and return a socket handle with attestation result. */
 export declare function atlsConnect(targetHost: string, serverName: string, policyJson: any): Promise<JsAtlsConnection>
+/**
+ * Re-attest the connection in-band if its attestation evidence is older
+ * than the policy's `reattestation_interval_secs`.
+ *
+ * Must only be called while the connection is quiescent (no request or
+ * response in flight): the exchange sends a `POST /tdx_quote` on the live
+ * TLS stream and reads its response, holding both socket-half locks for the
+ * duration so concurrent reads/writes block instead of interleaving.
+ *
+ * Returns the fresh attestation when re-attestation ran, or `null` when the
+ * evidence was still fresh (or re-attestation is disabled). On failure the
+ * socket is torn down (fail closed) and an error is thrown; reconnecting
+ * performs a full fresh attestation.
+ */
+export declare function socketReattestIfDue(socketId: number): Promise<JsAttestation | null>
 /** Read data from socket */
 export declare function socketRead(socketId: number, size?: number | undefined | null): Promise<Buffer>
 /** Write data to socket */

--- a/node/pnpm-lock.yaml
+++ b/node/pnpm-lock.yaml
@@ -23,6 +23,25 @@ importers:
       zod:
         specifier: ^4.1.13
         version: 4.1.13
+    optionalDependencies:
+      '@concrete-security/atlas-node-darwin-arm64':
+        specifier: 0.3.0
+        version: 0.3.0
+      '@concrete-security/atlas-node-darwin-x64':
+        specifier: 0.3.0
+        version: 0.3.0
+      '@concrete-security/atlas-node-linux-arm64-gnu':
+        specifier: 0.3.0
+        version: 0.3.0
+      '@concrete-security/atlas-node-linux-x64-gnu':
+        specifier: 0.3.0
+        version: 0.3.0
+      '@concrete-security/atlas-node-win32-arm64-msvc':
+        specifier: 0.3.0
+        version: 0.3.0
+      '@concrete-security/atlas-node-win32-x64-msvc':
+        specifier: 0.3.0
+        version: 0.3.0
 
 packages:
 
@@ -47,6 +66,42 @@ packages:
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
     engines: {node: '>=18'}
+
+  '@concrete-security/atlas-node-darwin-arm64@0.3.0':
+    resolution: {integrity: sha512-Z0pQOPy5H6K0C3QzjLQ+OzeUaCpdgiNcE3qSNMS1jzRcLn+edjxTXn9Le+psIMa1CPb4BbBoYqPqn/k4i1uFSA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@concrete-security/atlas-node-darwin-x64@0.3.0':
+    resolution: {integrity: sha512-dkp5qywcJ0M51i0HxtXM1ttXajMMYzqc3uHRwNwf3GvcieeGchdyfrU2aYPww2LJ6F5RB/3SIz+ZRO2Vv5JIRw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@concrete-security/atlas-node-linux-arm64-gnu@0.3.0':
+    resolution: {integrity: sha512-BGhBTz5VK4O22IqyxtJR8nMa36ZoF6IAoJfwV/Uw8Rgk5uXHbIMltwaAXE/j/It/ywd0sofXx1jpTL00LW6c4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@concrete-security/atlas-node-linux-x64-gnu@0.3.0':
+    resolution: {integrity: sha512-pzIdsyb7bca256Wt+F+bqVYisnvTUbxlyd9D45RjQb2p2U8PDk2o/CdvYmyXWrRzM76Z7lackNQky7+wYJVyTA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@concrete-security/atlas-node-win32-arm64-msvc@0.3.0':
+    resolution: {integrity: sha512-iSaSRKBHWqfB4nYzT0ECsoOOjbW81SqyqGZVIXSCC4xeedgVkalfjK/KshZO5OqYq5CFbgqyt9u3P/FpCXalVA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@concrete-security/atlas-node-win32-x64-msvc@0.3.0':
+    resolution: {integrity: sha512-c2ahZ9xodyuMMMb6TMmbfCeOeacm0yqW66p+cP7vbZvR7fnrvBb2vXiZZyjMZarqEFaSvZSWSQNtJ4bFejdu7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@napi-rs/cli@2.18.4':
     resolution: {integrity: sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg==}
@@ -117,6 +172,24 @@ snapshots:
   '@ai-sdk/provider@2.0.0':
     dependencies:
       json-schema: 0.4.0
+
+  '@concrete-security/atlas-node-darwin-arm64@0.3.0':
+    optional: true
+
+  '@concrete-security/atlas-node-darwin-x64@0.3.0':
+    optional: true
+
+  '@concrete-security/atlas-node-linux-arm64-gnu@0.3.0':
+    optional: true
+
+  '@concrete-security/atlas-node-linux-x64-gnu@0.3.0':
+    optional: true
+
+  '@concrete-security/atlas-node-win32-arm64-msvc@0.3.0':
+    optional: true
+
+  '@concrete-security/atlas-node-win32-x64-msvc@0.3.0':
+    optional: true
 
   '@napi-rs/cli@2.18.4': {}
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,11 +1,11 @@
+use atlas_rs::{
+    atls_connect as core_atls_connect, dstack::merge_with_default_app_compose, Policy, Report,
+    TlsStream as CoreTlsStream,
+};
 use bytes::{Bytes, BytesMut};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use once_cell::sync::Lazy;
-use atlas_rs::{
-    dstack::merge_with_default_app_compose, atls_connect as core_atls_connect, Policy, Report,
-    TlsStream as CoreTlsStream,
-};
 use rustls::crypto::aws_lc_rs::default_provider;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -97,14 +97,9 @@ pub async fn atls_connect(
         .await
         .map_err(|err| Error::from_reason(format!("tcp connect failed: {err}")))?;
 
-    let (tls, report) = core_atls_connect(
-        tcp,
-        &server_name,
-        policy,
-        Some(vec!["http/1.1".into()]),
-    )
-    .await
-    .map_err(|err| Error::from_reason(format!("atls handshake failed: {err}")))?;
+    let (tls, report) = core_atls_connect(tcp, &server_name, policy, Some(vec!["http/1.1".into()]))
+        .await
+        .map_err(|err| Error::from_reason(format!("atls handshake failed: {err}")))?;
 
     let socket_id = NEXT_SOCKET_ID.fetch_add(1, Ordering::SeqCst);
     let (reader, writer) = tokio::io::split(tls);
@@ -165,10 +160,12 @@ pub async fn socket_write(socket_id: u32, data: Buffer) -> napi::Result<u32> {
     let bytes = Bytes::from(data.to_vec());
     {
         let mut writer = writer.lock().await;
-        writer.write_all(&bytes)
+        writer
+            .write_all(&bytes)
             .await
             .map_err(|e| Error::from_reason(format!("socket write error: {e}")))?;
-        writer.flush()
+        writer
+            .flush()
             .await
             .map_err(|e| Error::from_reason(format!("socket flush error: {e}")))?;
     }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,6 +1,6 @@
 use atlas_rs::{
-    atls_connect as core_atls_connect, dstack::merge_with_default_app_compose, Policy, Report,
-    TlsStream as CoreTlsStream,
+    atls_connect_with_reattester as core_atls_connect_with_reattester,
+    dstack::merge_with_default_app_compose, Policy, Reattester, Report, TlsStream as CoreTlsStream,
 };
 use bytes::{Bytes, BytesMut};
 use napi::bindgen_prelude::*;
@@ -51,6 +51,10 @@ pub struct JsAtlsConnection {
     #[napi(js_name = "socketId")]
     pub socket_id: u32,
     pub attestation: JsAttestation,
+    /// Max age (seconds) of attestation evidence before transparent
+    /// re-attestation, from the policy. 0 means re-attestation is disabled.
+    #[napi(js_name = "reattestationIntervalSecs")]
+    pub reattestation_interval_secs: u32,
 }
 
 type TlsStream = CoreTlsStream<TcpStream>;
@@ -58,7 +62,12 @@ type TlsStream = CoreTlsStream<TcpStream>;
 struct SocketState {
     reader: Arc<Mutex<ReadHalf<TlsStream>>>,
     writer: Arc<Mutex<WriteHalf<TlsStream>>>,
+    reattester: Arc<Reattester>,
 }
+
+/// Upper bound on one in-band re-attestation exchange (quote generation,
+/// possible collateral fetch, and DCAP verification included).
+const REATTEST_TIMEOUT_SECS: u64 = 30;
 
 static SOCKETS: Lazy<Mutex<HashMap<u32, SocketState>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 static NEXT_SOCKET_ID: AtomicU32 = AtomicU32::new(1);
@@ -97,10 +106,12 @@ pub async fn atls_connect(
         .await
         .map_err(|err| Error::from_reason(format!("tcp connect failed: {err}")))?;
 
-    let (tls, report) = core_atls_connect(tcp, &server_name, policy, Some(vec!["http/1.1".into()]))
-        .await
-        .map_err(|err| Error::from_reason(format!("atls handshake failed: {err}")))?;
+    let (tls, report, reattester) =
+        core_atls_connect_with_reattester(tcp, &server_name, policy, Some(vec!["http/1.1".into()]))
+            .await
+            .map_err(|err| Error::from_reason(format!("atls handshake failed: {err}")))?;
 
+    let reattestation_interval_secs = reattester.interval_secs().min(u32::MAX as u64) as u32;
     let socket_id = NEXT_SOCKET_ID.fetch_add(1, Ordering::SeqCst);
     let (reader, writer) = tokio::io::split(tls);
     SOCKETS.lock().await.insert(
@@ -108,13 +119,87 @@ pub async fn atls_connect(
         SocketState {
             reader: Arc::new(Mutex::new(reader)),
             writer: Arc::new(Mutex::new(writer)),
+            reattester: Arc::new(reattester),
         },
     );
 
     Ok(JsAtlsConnection {
         socket_id,
         attestation: report.into(),
+        reattestation_interval_secs,
     })
+}
+
+/// Re-attest the connection in-band if its attestation evidence is older
+/// than the policy's `reattestation_interval_secs`.
+///
+/// Must only be called while the connection is quiescent (no request or
+/// response in flight): the exchange sends a `POST /tdx_quote` on the live
+/// TLS stream and reads its response, holding both socket-half locks for the
+/// duration so concurrent reads/writes block instead of interleaving.
+///
+/// Returns the fresh attestation when re-attestation ran, or `null` when the
+/// evidence was still fresh (or re-attestation is disabled). On failure the
+/// socket is torn down (fail closed) and an error is thrown; reconnecting
+/// performs a full fresh attestation.
+#[napi(js_name = "socketReattestIfDue")]
+pub async fn socket_reattest_if_due(socket_id: u32) -> napi::Result<Option<JsAttestation>> {
+    let (reader, writer, reattester) = {
+        let guard = SOCKETS.lock().await;
+        let Some(state) = guard.get(&socket_id) else {
+            return Err(Error::from_reason("socket not found"));
+        };
+        (
+            state.reader.clone(),
+            state.writer.clone(),
+            state.reattester.clone(),
+        )
+    };
+
+    // Fast path without touching the socket locks.
+    if !reattester.is_due() {
+        return Ok(None);
+    }
+
+    // Lock order: writer then reader. Only this function ever holds both.
+    let mut writer_guard = writer.lock().await;
+    let mut reader_guard = reader.lock().await;
+
+    // Re-check under the locks: a concurrent caller may have already
+    // re-attested while we waited.
+    if !reattester.is_due() {
+        return Ok(None);
+    }
+
+    let mut joined = tokio::io::join(&mut *reader_guard, &mut *writer_guard);
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(REATTEST_TIMEOUT_SECS),
+        reattester.reattest(&mut joined),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(report)) => Ok(Some(report.into())),
+        Ok(Err(e)) => {
+            // Fail closed: tear the connection down.
+            drop(reader_guard);
+            let _ = writer_guard.shutdown().await;
+            drop(writer_guard);
+            SOCKETS.lock().await.remove(&socket_id);
+            Err(Error::from_reason(format!("reattestation failed: {e}")))
+        }
+        Err(_elapsed) => {
+            // The exchange was cut off mid-flight; the stream state is
+            // undefined, so the connection cannot be reused.
+            drop(reader_guard);
+            let _ = writer_guard.shutdown().await;
+            drop(writer_guard);
+            SOCKETS.lock().await.remove(&socket_id);
+            Err(Error::from_reason(format!(
+                "reattestation failed: timed out after {REATTEST_TIMEOUT_SECS}s"
+            )))
+        }
+    }
 }
 
 /// Read data from socket
@@ -228,5 +313,31 @@ mod tests {
         let id1 = NEXT_SOCKET_ID.fetch_add(1, Ordering::SeqCst);
         let id2 = NEXT_SOCKET_ID.fetch_add(1, Ordering::SeqCst);
         assert!(id2 > id1);
+    }
+
+    /// The re-attestation exchange recombines the locked split halves with
+    /// `tokio::io::join`; prove that adapter reads and writes correctly.
+    #[tokio::test]
+    async fn join_over_locked_halves_roundtrips() {
+        let (client, mut server) = tokio::io::duplex(1024);
+        let (reader, writer) = tokio::io::split(client);
+        let reader = Arc::new(Mutex::new(reader));
+        let writer = Arc::new(Mutex::new(writer));
+
+        // Same locking pattern as socket_reattest_if_due: writer then reader.
+        let mut writer_guard = writer.lock().await;
+        let mut reader_guard = reader.lock().await;
+        let mut joined = tokio::io::join(&mut *reader_guard, &mut *writer_guard);
+
+        joined.write_all(b"ping").await.unwrap();
+        joined.flush().await.unwrap();
+        let mut request = [0u8; 4];
+        server.read_exact(&mut request).await.unwrap();
+        assert_eq!(&request, b"ping");
+
+        server.write_all(b"pong").await.unwrap();
+        let mut response = [0u8; 4];
+        joined.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"pong");
     }
 }

--- a/node/test.mjs
+++ b/node/test.mjs
@@ -324,6 +324,53 @@ const tests = [
     agent.destroy()
   }),
 
+  test("AtlsAgent denies reuse of sockets with expired evidence", async () => {
+    const agent = createAtlsAgent({ target: "example.com:443", policy: DEV_POLICY })
+
+    const socket = new EventEmitter()
+    socket.atlsExpiresAt = Date.now() - 1
+    socket.atlsIdle = true
+    let destroyed = false
+    socket.destroy = () => { destroyed = true; return socket }
+    socket.setKeepAlive = () => socket
+    socket.setTimeout = () => socket
+    socket.ref = () => socket
+    socket.unref = () => socket
+
+    let reqErr = null
+    const fakeReq = { destroy(err) { reqErr = err } }
+
+    agent.reuseSocket(socket, fakeReq)
+
+    assert(destroyed, "expired socket must be destroyed at reuse")
+    assert(reqErr, "the denied request must receive an error")
+    assert(reqErr.code === "ATLS_EVIDENCE_EXPIRED", `wrong error code: ${reqErr?.code}`)
+    agent.destroy()
+  }),
+
+  test("armEvidenceExpiry arms a chained timer beyond the setTimeout clamp", async () => {
+    const { armEvidenceExpiry, atlsEvidenceExpired } = _internals
+
+    const socket = new EventEmitter()
+    socket.destroy = () => socket
+    // Interval beyond the 2^31-1 ms setTimeout clamp (~24.8 days): a single
+    // oversized setTimeout would fire after ~1 ms; the chained timer must
+    // still be armed instead of skipped.
+    const intervalSecs = Math.ceil((0x7fffffff + 1) / 1000) + 60
+    armEvidenceExpiry(socket, intervalSecs)
+
+    assert(Number.isFinite(socket.atlsExpiresAt), "expiry deadline must be tracked")
+    assert(socket.listenerCount("close") === 1, "timer cleanup listener must be armed")
+    assert(atlsEvidenceExpired(socket) === false, "not expired yet")
+
+    // A socket past its deadline (e.g. expired while idle) reads as expired
+    // regardless of the timer, which reuseSocket enforces at dispatch.
+    socket.atlsExpiresAt = Date.now() - 1
+    assert(atlsEvidenceExpired(socket) === true, "past deadline must read expired")
+
+    socket.emit("close") // clears the chained timer
+  }),
+
   test("Bun pool re-attests reused connections and refreshes attestation", async () => {
     const { createConnectionPool } = _internals
     const events = []

--- a/node/test.mjs
+++ b/node/test.mjs
@@ -4,7 +4,8 @@
  * Run with: npm test
  */
 
-import { createAtlsAgent, createAtlsFetch, mergeWithDefaultAppCompose } from "./atls-fetch.js"
+import { createAtlsAgent, createAtlsFetch, mergeWithDefaultAppCompose, _internals } from "./atls-fetch.js"
+import { EventEmitter } from "events"
 import { createRequire } from "module"
 import { readFileSync } from "fs"
 import { dirname, join } from "path"
@@ -263,6 +264,143 @@ const tests = [
     assert(typeof mainExports.createAtlsFetch === "function", "createAtlsFetch not exported")
     assert(typeof mainExports.createAtlsAgent === "function", "createAtlsAgent not exported")
     assert(typeof mainExports.mergeWithDefaultAppCompose === "function", "mergeWithDefaultAppCompose not exported")
+  }),
+
+  test("Native binding exposes socketReattestIfDue", async () => {
+    assert(typeof binding.socketReattestIfDue === "function", "socketReattestIfDue not available")
+  }),
+
+  test("armEvidenceExpiry: interval 0 disables expiry", async () => {
+    const { armEvidenceExpiry, atlsEvidenceExpired } = _internals
+
+    const disabled = { once() {}, destroy() {} }
+    armEvidenceExpiry(disabled, 0)
+    assert(disabled.atlsExpiresAt === Infinity, "interval 0 must mean no expiry")
+    assert(atlsEvidenceExpired(disabled) === false, "disabled socket never expires")
+
+    const armed = { once() {}, destroy() {} }
+    armEvidenceExpiry(armed, 300)
+    assert(armed.atlsExpiresAt > Date.now(), "expiry must be in the future")
+    assert(atlsEvidenceExpired(armed) === false, "fresh evidence must not be expired")
+  }),
+
+  test("AtlsAgent retires sockets with expired attestation evidence", async () => {
+    const agent = createAtlsAgent({ target: "example.com:443", policy: DEV_POLICY })
+    // Real EventEmitter so Node's Agent internals (listener bookkeeping)
+    // work; socket-tuning methods stubbed like createAtlsDuplex does.
+    const fakeSocket = () => {
+      const s = new EventEmitter()
+      s.atlsIdle = false
+      s.setKeepAlive = () => s
+      s.setTimeout = () => s
+      s.ref = () => s
+      s.unref = () => s
+      s.destroy = () => s
+      return s
+    }
+
+    // Expired: never pooled again.
+    const expired = fakeSocket()
+    expired.atlsExpiresAt = Date.now() - 1
+    assert(agent.keepSocketAlive(expired) === false, "expired socket must be retired")
+    assert(expired.atlsIdle === true, "keepSocketAlive should mark the socket idle")
+
+    // Flagged expired while busy: retired when the response completes.
+    const flagged = fakeSocket()
+    flagged.atlsExpiresAt = Date.now() + 60_000
+    flagged.atlsExpired = true
+    assert(agent.keepSocketAlive(flagged) === false, "flagged socket must be retired")
+
+    // Fresh: pooled normally.
+    const fresh = fakeSocket()
+    fresh.atlsExpiresAt = Date.now() + 60_000
+    assert(agent.keepSocketAlive(fresh) === true, "fresh socket must be kept alive")
+
+    // reuseSocket clears the idle marker.
+    fresh.atlsIdle = true
+    agent.reuseSocket(fresh, {})
+    assert(fresh.atlsIdle === false, "reuseSocket should mark the socket busy")
+
+    agent.destroy()
+  }),
+
+  test("Bun pool re-attests reused connections and refreshes attestation", async () => {
+    const { createConnectionPool } = _internals
+    const events = []
+    const freshAttestation = { trusted: true, teeType: "tdx", tcbStatus: "UpToDate", advisoryIds: [] }
+    let connects = 0
+    const pool = createConnectionPool(
+      { hostPort: "example.com:443" },
+      "example.com",
+      DEV_POLICY,
+      (att) => events.push(att),
+      {
+        atlsConnect: async () => ({ socketId: ++connects, attestation: { trusted: true } }),
+        socketReattestIfDue: async () => freshAttestation,
+        socketDestroy: () => {},
+      },
+    )
+
+    const first = await pool.acquire()
+    assert(first.socketId === 1, "first acquire should connect")
+    pool.release(first.socketId)
+
+    const second = await pool.acquire()
+    assert(second.socketId === 1, "connection should be reused")
+    assert(second.attestation === freshAttestation, "attestation should be refreshed")
+    assert(events.length === 2, "onAttestation should fire on connect and on re-attestation")
+    assert(events[1] === freshAttestation, "re-attestation result should reach onAttestation")
+  }),
+
+  test("Bun pool skips re-attestation when evidence is fresh", async () => {
+    const { createConnectionPool } = _internals
+    const events = []
+    const initialAttestation = { trusted: true }
+    const pool = createConnectionPool(
+      { hostPort: "example.com:443" },
+      "example.com",
+      DEV_POLICY,
+      (att) => events.push(att),
+      {
+        atlsConnect: async () => ({ socketId: 7, attestation: initialAttestation }),
+        socketReattestIfDue: async () => null, // not due
+        socketDestroy: () => {},
+      },
+    )
+
+    const first = await pool.acquire()
+    pool.release(first.socketId)
+    const second = await pool.acquire()
+
+    assert(second.socketId === 7, "connection should be reused")
+    assert(second.attestation === initialAttestation, "attestation should be unchanged")
+    assert(events.length === 1, "onAttestation should only fire for the initial connect")
+  }),
+
+  test("Bun pool reconnects when re-attestation fails", async () => {
+    const { createConnectionPool } = _internals
+    const destroyed = []
+    let connects = 0
+    const pool = createConnectionPool(
+      { hostPort: "example.com:443" },
+      "example.com",
+      DEV_POLICY,
+      null,
+      {
+        atlsConnect: async () => ({ socketId: ++connects, attestation: {} }),
+        socketReattestIfDue: async () => {
+          throw new Error("reattestation failed: certificate not in event log")
+        },
+        socketDestroy: (id) => destroyed.push(id),
+      },
+    )
+
+    const first = await pool.acquire()
+    pool.release(first.socketId)
+
+    const second = await pool.acquire()
+    assert(second.socketId === 2, "a fresh, fully attested connection should be opened")
+    assert(destroyed.includes(1), "the failed connection should be destroyed")
   }),
 
   // Skipped: live enclave vllm.concrete-security.com decommissioned. Repoint to a

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 atlas-rs = { path = "../core" }
 pyo3 = { version = "0.24", features = ["extension-module"] }
 serde_json = { workspace = true }
-tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util"] }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "time"] }
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 once_cell = "1.19"
 hex = "0.4"

--- a/python/README.md
+++ b/python/README.md
@@ -84,6 +84,7 @@ Build a DStack TDX attestation policy dict
 | `app_compose_allowed_envs` | `list[str] \| None` | Override `allowed_envs` in app_compose |
 | `pccs_url` | `str \| None` | Intel PCCS URL for collateral |
 | `cache_collateral` | `bool` | Cache Intel collateral between verifications |
+| `reattestation_interval_secs` | `int \| None` | Max age (seconds) of attestation evidence before transparent re-attestation. Omitted = core default (300). `0` disables; non-zero values below 30 are rejected |
 
 ### `atlas.policy.dev_policy()`
 
@@ -109,6 +110,13 @@ Python bindings use the Rust core via PyO3 for the full aTLS pipeline:
 3. **Attestation** - Rust fetches and verifies the TDX quote against the policy
 4. **Stream Return** - The attested TLS stream is returned to Python
 5. **HTTP** - httpx sends requests over the attested stream
+6. **Re-attestation** - When a reused connection's evidence is older than
+   `reattestation_interval_secs` (default 300; `0` disables), Rust
+   transparently re-attests it in-band before the next request is sent. A
+   failed re-attestation closes the connection and raises
+   `atlas.ReattestationError` (fail closed); retrying gets a fresh, fully
+   attested connection. `response.extensions["attestation"]` always reflects
+   the latest verification.
 
 All TLS and verification happens in Rust. Python handles HTTP protocol and provides the httpx/API wrapper.
 

--- a/python/src/atlas/__init__.py
+++ b/python/src/atlas/__init__.py
@@ -4,7 +4,7 @@ import os
 from . import httpx
 from .policy import dev_policy, dstack_tdx_policy, merge_with_default_app_compose
 from .utils import _get_default_logger
-from .verifiers.errors import AtlsVerificationError
+from .verifiers.errors import AtlsVerificationError, ReattestationError
 
 logger = _get_default_logger()
 
@@ -20,4 +20,5 @@ __all__ = [
     "dev_policy",
     "merge_with_default_app_compose",
     "AtlsVerificationError",
+    "ReattestationError",
 ]

--- a/python/src/atlas/_atlas.pyi
+++ b/python/src/atlas/_atlas.pyi
@@ -1,5 +1,12 @@
 """Type stubs for the Rust _atlas extension module (PyO3)."""
 
+class ReattestationError(Exception):
+    """Re-attestation of an established aTLS connection failed.
+
+    The connection has been closed (fail closed); reconnecting performs a
+    full fresh attestation.
+    """
+
 class AtlsConnection:
     """An attested TLS connection backed by Rust."""
 

--- a/python/src/atlas/httpx/transport.py
+++ b/python/src/atlas/httpx/transport.py
@@ -25,6 +25,14 @@ class AtlsNetworkStream(httpcore.NetworkStream):
     Rust owns the TLS session. This stream proxies read/write to it.
     ``start_tls`` is a no-op because TLS was already established by Rust.
 
+    **Re-attestation**: when the connection's attestation evidence is older
+    than the policy's ``reattestation_interval_secs`` (default 300; 0
+    disables), the Rust side transparently re-attests it in-band at the next
+    message boundary (the first ``write`` of a new request). On failure the
+    connection is closed and ``write`` raises
+    :class:`atlas.ReattestationError` (fail closed); retrying the request
+    gets a fresh, fully attested connection from the pool.
+
     **Limitation**: ``timeout`` parameters on ``read``/``write`` are not
     forwarded to the Rust side. The Rust tokio runtime manages its own I/O
     scheduling. httpx-level timeouts (e.g. ``httpx.Timeout``) will not be

--- a/python/src/atlas/policy.py
+++ b/python/src/atlas/policy.py
@@ -39,6 +39,7 @@ def dstack_tdx_policy(
     app_compose_allowed_envs: Optional[list[str]] = None,
     pccs_url: Optional[str] = None,
     cache_collateral: bool = False,
+    reattestation_interval_secs: Optional[int] = None,
 ) -> dict:
     """Build a DstackTdx attestation policy dict.
 
@@ -63,6 +64,11 @@ def dstack_tdx_policy(
             app_compose.
         pccs_url: PCCS URL for Intel collateral fetching.
         cache_collateral: Cache Intel collateral between verifications.
+        reattestation_interval_secs: Max age (seconds) of attestation
+            evidence before the connection is transparently re-attested.
+            When omitted, the Rust core default of 300 seconds applies.
+            Pass ``0`` to disable re-attestation completely; non-zero
+            values below 30 are rejected by the core.
 
     Returns:
         Policy dict like ``{"type": "dstack_tdx", ...}``.
@@ -88,6 +94,9 @@ def dstack_tdx_policy(
 
     if pccs_url is not None:
         policy["pccs_url"] = pccs_url
+
+    if reattestation_interval_secs is not None:
+        policy["reattestation_interval_secs"] = reattestation_interval_secs
 
     if not disable_runtime_verification:
         # Build app_compose

--- a/python/src/atlas/verifiers/errors.py
+++ b/python/src/atlas/verifiers/errors.py
@@ -1,4 +1,10 @@
+from .._atlas import ReattestationError
+
+
 class AtlsVerificationError(Exception):
     """Exception raised when aTLS verification fails."""
 
     pass
+
+
+__all__ = ["AtlsVerificationError", "ReattestationError"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -52,10 +52,7 @@ impl From<Report> for Attestation {
     fn from(report: Report) -> Self {
         match report {
             Report::Tdx(verified) => {
-                let measurement = verified
-                    .report
-                    .as_td10()
-                    .map(|td| hex::encode(td.mr_td));
+                let measurement = verified.report.as_td10().map(|td| hex::encode(td.mr_td));
                 Self {
                     trusted: true,
                     tee_type: "tdx".to_string(),

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,18 +1,27 @@
 use atlas_rs::{
-    atls_connect as core_atls_connect, dstack::merge_with_default_app_compose, Policy, Report,
-    TlsStream as CoreTlsStream,
+    atls_connect_with_reattester as core_atls_connect_with_reattester,
+    dstack::merge_with_default_app_compose, Policy, Reattester, Report, TlsStream as CoreTlsStream,
 };
 use once_cell::sync::Lazy;
-use pyo3::exceptions::{PyConnectionError, PyIOError, PyValueError};
+use pyo3::exceptions::{PyConnectionError, PyException, PyIOError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use rustls::crypto::aws_lc_rs::default_provider;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
+
+pyo3::create_exception!(
+    _atlas,
+    ReattestationError,
+    PyException,
+    "Re-attestation of an established aTLS connection failed; the connection \
+     has been closed (fail closed). Reconnecting performs a full fresh \
+     attestation."
+);
 
 // Lazily initialized tokio runtime shared across all connections.
 static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
@@ -33,7 +42,17 @@ struct ConnectionState {
     reader: Arc<Mutex<ReadHalf<TlsStream>>>,
     writer: Arc<Mutex<WriteHalf<TlsStream>>>,
     attestation: Attestation,
+    reattester: Arc<Reattester>,
+    /// Set by `read()`, consumed by `write()`: a write directly following a
+    /// read marks a message boundary (sync HTTP/1.1 never interleaves reads
+    /// and writes within one message), which is the only safe point to
+    /// re-attest in-band.
+    saw_read: Arc<AtomicBool>,
 }
+
+/// Upper bound on one in-band re-attestation exchange (quote generation,
+/// possible collateral fetch, and DCAP verification included).
+const REATTEST_TIMEOUT_SECS: u64 = 30;
 
 static CONNECTIONS: Lazy<Mutex<HashMap<u64, ConnectionState>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
@@ -103,12 +122,12 @@ impl AtlsConnection {
         let conn_id = self.conn_id;
         py.allow_threads(|| {
             RUNTIME.block_on(async {
-                let reader = {
+                let (reader, saw_read) = {
                     let guard = CONNECTIONS.lock().await;
                     let state = guard
                         .get(&conn_id)
                         .ok_or_else(|| PyIOError::new_err("connection closed"))?;
-                    state.reader.clone()
+                    (state.reader.clone(), state.saw_read.clone())
                 };
 
                 let mut buf = vec![0u8; size];
@@ -116,6 +135,7 @@ impl AtlsConnection {
                 match reader.read(&mut buf).await {
                     Ok(0) => Ok(Vec::new()),
                     Ok(n) => {
+                        saw_read.store(true, Ordering::Release);
                         buf.truncate(n);
                         Ok(buf)
                     }
@@ -128,18 +148,38 @@ impl AtlsConnection {
     /// Write data to the attested TLS stream.
     ///
     /// Returns the number of bytes written. The GIL is released during the write.
+    ///
+    /// The first write after a read marks a message boundary; if the
+    /// attestation evidence is older than the policy's
+    /// ``reattestation_interval_secs`` at that point, the connection is
+    /// transparently re-attested in-band first. A failed re-attestation
+    /// closes the connection and raises ``ReattestationError`` (fail closed);
+    /// retrying on a new connection performs a full fresh attestation.
     fn write(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<usize> {
         let conn_id = self.conn_id;
         let len = data.len();
         py.allow_threads(|| {
             RUNTIME.block_on(async {
-                let writer = {
+                let (writer, reader, reattester, saw_read) = {
                     let guard = CONNECTIONS.lock().await;
                     let state = guard
                         .get(&conn_id)
                         .ok_or_else(|| PyIOError::new_err("connection closed"))?;
-                    state.writer.clone()
+                    (
+                        state.writer.clone(),
+                        state.reader.clone(),
+                        state.reattester.clone(),
+                        state.saw_read.clone(),
+                    )
                 };
+
+                // Consume the boundary marker atomically so only the first
+                // write after a read can trigger re-attestation (later body
+                // chunk writes of the same request never do).
+                let at_boundary = saw_read.swap(false, Ordering::AcqRel);
+                if at_boundary && reattester.is_due() {
+                    reattest_locked(conn_id, &reader, &writer, &reattester).await?;
+                }
 
                 let mut writer = writer.lock().await;
                 writer
@@ -197,6 +237,64 @@ impl AtlsConnection {
     }
 }
 
+/// Re-attest in-band over the recombined stream halves, failing closed.
+///
+/// Takes both half-locks (writer then reader; only this function ever holds
+/// both) so no other I/O can interleave with the quote exchange, re-checks
+/// due-ness under the locks (a concurrent caller may have already
+/// re-attested), and bounds the exchange with a timeout. On success the
+/// stored attestation is refreshed; on failure or timeout the connection is
+/// shut down and removed, and ``ReattestationError`` is raised.
+async fn reattest_locked(
+    conn_id: u64,
+    reader: &Arc<Mutex<ReadHalf<TlsStream>>>,
+    writer: &Arc<Mutex<WriteHalf<TlsStream>>>,
+    reattester: &Reattester,
+) -> PyResult<()> {
+    let mut writer_guard = writer.lock().await;
+    let mut reader_guard = reader.lock().await;
+
+    if !reattester.is_due() {
+        return Ok(());
+    }
+
+    let mut joined = tokio::io::join(&mut *reader_guard, &mut *writer_guard);
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(REATTEST_TIMEOUT_SECS),
+        reattester.reattest(&mut joined),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(report)) => {
+            drop(reader_guard);
+            drop(writer_guard);
+            if let Some(state) = CONNECTIONS.lock().await.get_mut(&conn_id) {
+                state.attestation = report.into();
+            }
+            Ok(())
+        }
+        Ok(Err(e)) => {
+            drop(reader_guard);
+            let _ = writer_guard.shutdown().await;
+            drop(writer_guard);
+            CONNECTIONS.lock().await.remove(&conn_id);
+            Err(ReattestationError::new_err(format!("{e}")))
+        }
+        Err(_elapsed) => {
+            // The exchange was cut off mid-flight; the stream state is
+            // undefined, so the connection cannot be reused.
+            drop(reader_guard);
+            let _ = writer_guard.shutdown().await;
+            drop(writer_guard);
+            CONNECTIONS.lock().await.remove(&conn_id);
+            Err(ReattestationError::new_err(format!(
+                "re-attestation failed: timed out after {REATTEST_TIMEOUT_SECS}s"
+            )))
+        }
+    }
+}
+
 /// Establish an attested TLS connection to a TEE endpoint.
 ///
 /// Creates a TCP connection, performs TLS handshake, and runs attestation
@@ -239,10 +337,14 @@ fn atls_connect(
                 .await
                 .map_err(|e| PyConnectionError::new_err(format!("tcp connect failed: {e}")))?;
 
-            let (tls, report) =
-                core_atls_connect(tcp, &server_name, policy, Some(vec!["http/1.1".into()]))
-                    .await
-                    .map_err(|e| PyIOError::new_err(format!("atls handshake failed: {e}")))?;
+            let (tls, report, reattester) = core_atls_connect_with_reattester(
+                tcp,
+                &server_name,
+                policy,
+                Some(vec!["http/1.1".into()]),
+            )
+            .await
+            .map_err(|e| PyIOError::new_err(format!("atls handshake failed: {e}")))?;
 
             let conn_id = NEXT_CONN_ID.fetch_add(1, Ordering::SeqCst);
             let (reader, writer) = tokio::io::split(tls);
@@ -255,6 +357,8 @@ fn atls_connect(
                     reader: Arc::new(Mutex::new(reader)),
                     writer: Arc::new(Mutex::new(writer)),
                     attestation,
+                    reattester: Arc::new(reattester),
+                    saw_read: Arc::new(AtomicBool::new(false)),
                 },
             );
 
@@ -287,5 +391,9 @@ fn _atlas(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<AtlsConnection>()?;
     m.add_function(wrap_pyfunction!(atls_connect, m)?)?;
     m.add_function(wrap_pyfunction!(merge_with_default_app_compose_py, m)?)?;
+    m.add(
+        "ReattestationError",
+        m.py().get_type::<ReattestationError>(),
+    )?;
     Ok(())
 }

--- a/python/tests/test_module_init.py
+++ b/python/tests/test_module_init.py
@@ -67,3 +67,12 @@ class TestModuleInit:
         assert hasattr(atlas, "dev_policy")
         assert hasattr(atlas, "merge_with_default_app_compose")
         assert hasattr(atlas, "AtlsVerificationError")
+        assert hasattr(atlas, "ReattestationError")
+
+    def test_reattestation_error_importable_from_errors_module(self):
+        """ReattestationError is re-exported next to AtlsVerificationError."""
+        from atlas import ReattestationError as top_level
+        from atlas.verifiers.errors import ReattestationError
+
+        assert top_level is ReattestationError
+        assert issubclass(ReattestationError, Exception)

--- a/python/tests/test_policy.py
+++ b/python/tests/test_policy.py
@@ -60,6 +60,27 @@ class TestDstackTdxPolicy:
         )
         assert policy["pccs_url"] == "https://custom-pccs.example.com"
 
+    def test_dstack_tdx_policy_omits_reattestation_interval_by_default(self):
+        """Omitting the kwarg leaves the key absent (Rust core default: 300s)."""
+        policy = dstack_tdx_policy(disable_runtime_verification=True)
+        assert "reattestation_interval_secs" not in policy
+
+    def test_dstack_tdx_policy_with_reattestation_interval(self):
+        """An explicit interval is included in the policy dict."""
+        policy = dstack_tdx_policy(
+            disable_runtime_verification=True,
+            reattestation_interval_secs=600,
+        )
+        assert policy["reattestation_interval_secs"] == 600
+
+    def test_dstack_tdx_policy_reattestation_interval_zero_disables(self):
+        """0 is passed through explicitly to disable re-attestation."""
+        policy = dstack_tdx_policy(
+            disable_runtime_verification=True,
+            reattestation_interval_secs=0,
+        )
+        assert policy["reattestation_interval_secs"] == 0
+
     def test_bootchain_without_os_image_hash_raises(self, bootchain):
         """Test that providing bootchain without os_image_hash raises ValueError."""
         with pytest.raises(ValueError, match="must be provided together"):

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -183,6 +183,24 @@ const fetch = createAtlsFetch({
 
 For complete policy field descriptions and verification flow, see [core/README.md#policy-configuration](../core/README.md#policy-configuration).
 
+### Periodic Re-attestation
+
+Cached connections are transparently re-attested by `createAtlsFetch` when
+their attestation evidence is older than the policy's
+`reattestation_interval_secs` (default `300`; set `0` to disable completely,
+non-zero values below `30` are rejected). Re-attestation repeats the full
+`/tdx_quote` verification over the live session with a fresh nonce bound to
+the same session EKM, before the request is dispatched. On failure the
+connection is dropped and a fresh, fully attested one is established (fail
+closed). `onAttestation` fires on each re-attestation, and
+`response.attestation` always reflects the evidence backing that request.
+
+With `AtlsHttp` directly, drive it yourself: check `isReattestationDue()`
+while the connection is idle (`isReady()`), call `await http.reattest()`, and
+`close()` the connection if it throws. `AttestedStream` does not support
+re-attestation (the caller owns the protocol framing) — reconnect
+periodically instead; every connect performs a full attestation.
+
 ## Protocol Details
 
 Browser WASM bindings follow the same aTLS protocol as other platforms.

--- a/wasm/proxy/tests/integration.rs
+++ b/wasm/proxy/tests/integration.rs
@@ -14,10 +14,7 @@ async fn get_available_port() -> u16 {
 
 /// Spawn the proxy server with given configuration.
 /// Returns the proxy listen address and a shutdown sender.
-async fn spawn_proxy(
-    target: &str,
-    allowlist: &str,
-) -> (String, tokio::task::JoinHandle<()>) {
+async fn spawn_proxy(target: &str, allowlist: &str) -> (String, tokio::task::JoinHandle<()>) {
     let proxy_port = get_available_port().await;
     let listen_addr = format!("127.0.0.1:{}", proxy_port);
     let listen_addr_clone = listen_addr.clone();
@@ -228,7 +225,8 @@ async fn test_websocket_target_from_query_param() {
 
     // Connect with target pointing to echo_addr2 via query param
     // URL encode the target to handle the colon properly
-    let encoded_target: String = url::form_urlencoded::byte_serialize(echo_addr2.as_bytes()).collect();
+    let encoded_target: String =
+        url::form_urlencoded::byte_serialize(echo_addr2.as_bytes()).collect();
     let url_with_target = format!("{}/tunnel?target={}", proxy_url, encoded_target);
     let (mut ws_stream, _) = connect_async(&url_with_target)
         .await

--- a/wasm/src/atls-fetch.d.ts
+++ b/wasm/src/atls-fetch.d.ts
@@ -2,14 +2,42 @@ export interface AttestationResult {
   trusted: boolean;
   teeType: string;
   tcbStatus: string;
+  advisoryIds: string[];
 }
+
+export interface DstackTdxPolicy {
+  type: "dstack_tdx";
+  expected_bootchain?: {
+    mrtd: string;
+    rtmr0: string;
+    rtmr1: string;
+    rtmr2: string;
+  };
+  os_image_hash?: string;
+  app_compose?: Record<string, unknown>;
+  allowed_tcb_status?: string[];
+  /**
+   * Max age (seconds) of attestation evidence before transparent
+   * re-attestation of the connection. Default: 300. Set to 0 to disable
+   * re-attestation completely; non-zero values below 30 are rejected.
+   */
+  reattestation_interval_secs?: number;
+  pccs_url?: string;
+  cache_collateral?: boolean;
+  disable_runtime_verification?: boolean;
+}
+
+export type Policy = DstackTdxPolicy;
 
 export interface AtlsFetchOptions {
   proxyUrl: string;
   targetHost: string;
+  /** Verification policy (required). */
+  policy: Policy;
   serverName?: string;
   defaultHeaders?: Record<string, string>;
-  onAttestation?: (attestation: AttestationResult) => void;
+  /** Called on new connections and on every re-attestation. */
+  onAttestation?: (attestation: AttestationResult) => void | Promise<void>;
 }
 
 export interface AtlsResponse extends Response {
@@ -21,4 +49,3 @@ export type AtlsFetch = (input: RequestInfo | URL, init?: RequestInit) => Promis
 export function createAtlsFetch(options: AtlsFetchOptions): AtlsFetch;
 
 export { AttestedStream } from "./atls_wasm.js";
-

--- a/wasm/src/atls-fetch.js
+++ b/wasm/src/atls-fetch.js
@@ -143,8 +143,11 @@ function buildProxyUrl(base, target) {
  * Create a fetch-compatible function for attested TLS connections.
  *
  * Connections are automatically pooled and reused for subsequent requests
- * to the same target. The `onAttestation` callback is called only once
- * when a new connection is established (not on reused connections).
+ * to the same target. Reused connections are transparently re-attested when
+ * their attestation evidence is older than the policy's
+ * `reattestation_interval_secs` (default 300 seconds; 0 disables). The
+ * `onAttestation` callback fires when a new connection is established and on
+ * every re-attestation.
  *
  * @param {Object} options
  * @param {string} options.proxyUrl - WebSocket proxy URL (e.g., "ws://127.0.0.1:9000")
@@ -152,7 +155,7 @@ function buildProxyUrl(base, target) {
  * @param {Object} options.policy - Verification policy
  * @param {string} [options.serverName] - TLS server name (defaults to hostname from targetHost)
  * @param {Object} [options.defaultHeaders] - Default headers to include in all requests
- * @param {Function} [options.onAttestation] - Callback when attestation is received (only on new connections)
+ * @param {Function} [options.onAttestation] - Callback invoked with the attestation result (on new connections and on every re-attestation)
  * @returns {Function} A fetch-compatible async function
  */
 export function createAtlsFetch(options) {
@@ -184,9 +187,30 @@ export function createAtlsFetch(options) {
     let http = connectionCache.get(cacheKey);
     let attestation;
 
+    // Transparently re-attest a reused connection whose attestation evidence
+    // is older than the policy's reattestation_interval_secs: a fresh nonce
+    // bound to the same session EKM, verified with the full pipeline.
+    if (http && http.isReady() && http.isReattestationDue()) {
+      try {
+        attestation = await http.reattest();
+        if (onAttestation && typeof onAttestation === "function") {
+          await onAttestation(attestation);
+        }
+      } catch (e) {
+        // Fail closed: drop the connection; the fresh connect below performs
+        // a full attestation.
+        console.warn("[atls-fetch] re-attestation failed, reconnecting:", e);
+        connectionCache.delete(cacheKey);
+        try { http.close(); } catch (_) {}
+        http = null;
+      }
+    }
+
     if (http && http.isReady()) {
-      // Reuse existing connection - no re-attestation needed
-      attestation = http.attestation();
+      // Reuse existing connection (evidence fresh or just re-attested)
+      if (attestation === undefined) {
+        attestation = http.attestation();
+      }
     } else {
       // Need to create a new connection
       // First, clean up any stale connection

--- a/wasm/src/hyper_io.rs
+++ b/wasm/src/hyper_io.rs
@@ -44,7 +44,8 @@ impl<T: AsyncRead> Read for HyperIo<T> {
         }
 
         // SAFETY: We just initialized the buffer
-        let initialized = unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut u8, len) };
+        let initialized =
+            unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut u8, len) };
 
         match self.project().inner.poll_read(cx, initialized) {
             Poll::Ready(Ok(n)) => {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -11,13 +11,15 @@
 mod hyper_io;
 
 use async_io_stream::IoStream;
+use atlas_rs::{
+    atls_connect, dstack::merge_with_default_app_compose, AsyncWriteExt, Policy, TlsStream,
+};
 use bytes::Bytes;
 use futures::io::{ReadHalf, WriteHalf};
 use futures::AsyncReadExt;
 use http_body_util::{BodyExt, Full};
 use hyper::client::conn::http1;
 use hyper::Request;
-use atlas_rs::{dstack::merge_with_default_app_compose, atls_connect, AsyncWriteExt, Policy, TlsStream};
 use serde::Serialize;
 use std::{cell::RefCell, rc::Rc};
 use wasm_bindgen::prelude::*;
@@ -56,28 +58,30 @@ fn create_readable_stream(reader: ReadHalf<TlsStream<WsIo>>) -> web_sys::Readabl
     let underlying_source = Object::new();
 
     let reader_clone = reader.clone();
-    let pull = Closure::wrap(Box::new(move |controller: ReadableStreamDefaultController| {
-        let reader = reader_clone.clone();
-        let promise = wasm_bindgen_futures::future_to_promise(async move {
-            let mut buf = vec![0u8; 16 * 1024];
-            let mut reader_ref = reader.borrow_mut();
-            match reader_ref.read(&mut buf).await {
-                Ok(0) => {
-                    controller.close().ok();
+    let pull = Closure::wrap(
+        Box::new(move |controller: ReadableStreamDefaultController| {
+            let reader = reader_clone.clone();
+            let promise = wasm_bindgen_futures::future_to_promise(async move {
+                let mut buf = vec![0u8; 16 * 1024];
+                let mut reader_ref = reader.borrow_mut();
+                match reader_ref.read(&mut buf).await {
+                    Ok(0) => {
+                        controller.close().ok();
+                    }
+                    Ok(n) => {
+                        let chunk = Uint8Array::from(&buf[..n]);
+                        controller.enqueue_with_chunk(&chunk.into()).ok();
+                    }
+                    Err(e) => {
+                        let error = JsValue::from_str(&e.to_string());
+                        controller.error_with_e(&error);
+                    }
                 }
-                Ok(n) => {
-                    let chunk = Uint8Array::from(&buf[..n]);
-                    controller.enqueue_with_chunk(&chunk.into()).ok();
-                }
-                Err(e) => {
-                    let error = JsValue::from_str(&e.to_string());
-                    controller.error_with_e(&error);
-                }
-            }
-            Ok(JsValue::UNDEFINED)
-        });
-        promise
-    }) as Box<dyn FnMut(ReadableStreamDefaultController) -> Promise>);
+                Ok(JsValue::UNDEFINED)
+            });
+            promise
+        }) as Box<dyn FnMut(ReadableStreamDefaultController) -> Promise>,
+    );
 
     Reflect::set(&underlying_source, &"pull".into(), pull.as_ref()).unwrap();
     pull.forget();
@@ -419,7 +423,11 @@ impl AtlsHttp {
         let headers_obj = Object::new();
         for (name, value) in response.headers() {
             let value_str = value.to_str().unwrap_or("");
-            Reflect::set(&headers_obj, &name.as_str().into(), &JsValue::from_str(value_str))?;
+            Reflect::set(
+                &headers_obj,
+                &name.as_str().into(),
+                &JsValue::from_str(value_str),
+            )?;
         }
 
         // Create ReadableStream from hyper body
@@ -450,38 +458,40 @@ fn create_hyper_body_stream(body: hyper::body::Incoming) -> web_sys::ReadableStr
     let body = Rc::new(RefCell::new(Some(body)));
     let underlying_source = Object::new();
 
-    let pull = Closure::wrap(Box::new(move |controller: ReadableStreamDefaultController| {
-        let body = body.clone();
+    let pull = Closure::wrap(
+        Box::new(move |controller: ReadableStreamDefaultController| {
+            let body = body.clone();
 
-        wasm_bindgen_futures::future_to_promise(async move {
-            let mut body_opt = body.borrow_mut();
+            wasm_bindgen_futures::future_to_promise(async move {
+                let mut body_opt = body.borrow_mut();
 
-            if let Some(body_inner) = body_opt.as_mut() {
-                // Try to get the next frame from the body
-                match body_inner.frame().await {
-                    Some(Ok(frame)) => {
-                        if let Some(data) = frame.data_ref() {
-                            let arr = Uint8Array::from(data.as_ref());
-                            controller.enqueue_with_chunk(&arr.into()).ok();
+                if let Some(body_inner) = body_opt.as_mut() {
+                    // Try to get the next frame from the body
+                    match body_inner.frame().await {
+                        Some(Ok(frame)) => {
+                            if let Some(data) = frame.data_ref() {
+                                let arr = Uint8Array::from(data.as_ref());
+                                controller.enqueue_with_chunk(&arr.into()).ok();
+                            }
+                            // If it's a trailers frame, we ignore it
                         }
-                        // If it's a trailers frame, we ignore it
+                        Some(Err(e)) => {
+                            let error = JsValue::from_str(&format!("Body read error: {e}"));
+                            controller.error_with_e(&error);
+                        }
+                        None => {
+                            // Body complete
+                            controller.close().ok();
+                        }
                     }
-                    Some(Err(e)) => {
-                        let error = JsValue::from_str(&format!("Body read error: {e}"));
-                        controller.error_with_e(&error);
-                    }
-                    None => {
-                        // Body complete
-                        controller.close().ok();
-                    }
+                } else {
+                    controller.close().ok();
                 }
-            } else {
-                controller.close().ok();
-            }
 
-            Ok(JsValue::UNDEFINED)
-        })
-    }) as Box<dyn FnMut(ReadableStreamDefaultController) -> Promise>);
+                Ok(JsValue::UNDEFINED)
+            })
+        }) as Box<dyn FnMut(ReadableStreamDefaultController) -> Promise>,
+    );
 
     Reflect::set(&underlying_source, &"pull".into(), pull.as_ref()).unwrap();
     pull.forget();

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -393,9 +393,10 @@ impl AtlsHttp {
         drop(sender_guard);
 
         // No RefCell borrow is held across this await (Reattester is &self).
+        // `finish` consumes the request: this exchange cannot be replayed.
         let report = self
             .reattester
-            .finish(&request, &body_bytes)
+            .finish(request, &body_bytes)
             .await
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -12,7 +12,8 @@ mod hyper_io;
 
 use async_io_stream::IoStream;
 use atlas_rs::{
-    atls_connect, dstack::merge_with_default_app_compose, AsyncWriteExt, Policy, TlsStream,
+    atls_connect, atls_connect_with_reattester, dstack::merge_with_default_app_compose,
+    AsyncWriteExt, Policy, ReattestRequest, Reattester, Report, TlsStream,
 };
 use bytes::Bytes;
 use futures::io::{ReadHalf, WriteHalf};
@@ -99,11 +100,29 @@ pub struct AttestationSummary {
     pub advisory_ids: Vec<String>,
 }
 
+fn summarize(report: &Report) -> AttestationSummary {
+    match report {
+        Report::Tdx(verified) => AttestationSummary {
+            trusted: true,
+            tee_type: "Tdx".to_string(),
+            tcb_status: verified.status.clone(),
+            advisory_ids: verified.advisory_ids.clone(),
+        },
+    }
+}
+
 /// An attested TLS stream over a WebSocket connection.
 ///
 /// Provides a native `ReadableStream` for response data and a `send` method
 /// for writing requests. This design allows zero-copy response streaming
 /// while keeping the write path simple.
+///
+/// Re-attestation is not supported on this low-level stream: the pull-based
+/// `ReadableStream` may hold a pending read, and the caller owns the
+/// application protocol framing, so an in-band quote exchange could
+/// interleave with application traffic. Use [`AtlsHttp`] for long-lived
+/// connections with transparent re-attestation, or reconnect periodically
+/// (every connect performs a full attestation).
 #[wasm_bindgen]
 pub struct AttestedStream {
     writer: Rc<RefCell<Option<WriteHalf<TlsStream<WsIo>>>>>,
@@ -153,18 +172,9 @@ impl AttestedStream {
 
         let readable = create_readable_stream(reader);
 
-        let attestation = match &report {
-            atlas_rs::Report::Tdx(verified) => AttestationSummary {
-                trusted: true,
-                tee_type: "Tdx".to_string(),
-                tcb_status: verified.status.clone(),
-                advisory_ids: verified.advisory_ids.clone(),
-            },
-        };
-
         Ok(AttestedStream {
             writer: Rc::new(RefCell::new(Some(writer))),
-            attestation,
+            attestation: summarize(&report),
             readable,
         })
     }
@@ -235,7 +245,12 @@ pub struct AtlsHttp {
     /// The hyper HTTP/1.1 sender - can make multiple requests on the same connection.
     /// Stored as Option to allow detecting when the connection is closed.
     sender: Rc<RefCell<Option<SendRequest<Full<Bytes>>>>>,
-    attestation: AttestationSummary,
+    /// Latest attestation result; refreshed by `reattest()`.
+    attestation: RefCell<AttestationSummary>,
+    /// Re-attestation handle retaining the verifier, session peer
+    /// certificate, and session EKM (captured before hyper consumed the
+    /// stream — the raw stream is unreachable afterwards).
+    reattester: Rc<Reattester>,
 }
 
 #[wasm_bindgen]
@@ -263,7 +278,7 @@ impl AtlsHttp {
             .await
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
-        let (tls, report) = atls_connect(
+        let (tls, report, reattester) = atls_connect_with_reattester(
             ws_stream.into_io(),
             server_name,
             policy,
@@ -272,14 +287,7 @@ impl AtlsHttp {
         .await
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
-        let attestation = match &report {
-            atlas_rs::Report::Tdx(verified) => AttestationSummary {
-                trusted: true,
-                tee_type: "Tdx".to_string(),
-                tcb_status: verified.status.clone(),
-                advisory_ids: verified.advisory_ids.clone(),
-            },
-        };
+        let attestation = summarize(&report);
 
         // Wrap TLS stream for hyper compatibility
         let io = HyperIo::new(tls);
@@ -302,15 +310,98 @@ impl AtlsHttp {
 
         Ok(AtlsHttp {
             sender: Rc::new(RefCell::new(Some(sender))),
-            attestation,
+            attestation: RefCell::new(attestation),
+            reattester: Rc::new(reattester),
         })
     }
 
-    /// Get attestation result.
+    /// Get the latest attestation result (refreshed by `reattest()`).
     #[wasm_bindgen(js_name = attestation)]
     pub fn attestation(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.attestation)
+        serde_wasm_bindgen::to_value(&*self.attestation.borrow())
             .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Whether the connection's attestation evidence is older than the
+    /// policy's `reattestation_interval_secs`.
+    ///
+    /// Always false when re-attestation is disabled (interval 0).
+    #[wasm_bindgen(js_name = isReattestationDue)]
+    pub fn is_reattestation_due(&self) -> bool {
+        self.reattester.is_due()
+    }
+
+    /// Re-attest the connection over the live HTTP/1.1 session.
+    ///
+    /// Sends a `POST /tdx_quote` request with a fresh nonce through the same
+    /// hyper connection and runs the full verification pipeline on the
+    /// response (`report_data = SHA512(nonce || session_ekm)` binds it to
+    /// this session). The connection must be idle — check `isReady()` first,
+    /// like `fetch()`.
+    ///
+    /// On success the stored attestation is refreshed and returned. On
+    /// failure the evidence stays stale and the connection must be closed
+    /// and replaced (fail closed); a fresh connect performs a full
+    /// attestation.
+    #[wasm_bindgen(js_name = reattest)]
+    pub async fn reattest(&self) -> Result<JsValue, JsValue> {
+        let request = self.reattester.begin();
+        let body_json = request.body_json();
+
+        // Mirrors fetch(): the sender borrow is held for the exchange, so a
+        // concurrent fetch()/reattest() is serialized by the JS caller via
+        // isReady(), exactly like concurrent fetch()+fetch().
+        let mut sender_guard = self.sender.borrow_mut();
+        let sender = sender_guard
+            .as_mut()
+            .ok_or_else(|| JsValue::from_str("connection closed"))?;
+
+        if !sender.is_ready() {
+            return Err(JsValue::from_str(
+                "connection busy - wait for previous response to complete",
+            ));
+        }
+
+        let http_request = Request::builder()
+            .method(ReattestRequest::method())
+            .uri(ReattestRequest::path())
+            .header("Host", self.reattester.server_name())
+            .header("Content-Type", ReattestRequest::content_type())
+            .header("Content-Length", body_json.len().to_string())
+            .body(Full::new(Bytes::from(body_json)))
+            .map_err(|e| JsValue::from_str(&format!("Failed to build request: {e}")))?;
+
+        let response = sender
+            .send_request(http_request)
+            .await
+            .map_err(|e| JsValue::from_str(&format!("reattestation failed: {e}")))?;
+
+        let status = response.status();
+        if status != hyper::StatusCode::OK {
+            return Err(JsValue::from_str(&format!(
+                "reattestation failed: /tdx_quote returned HTTP {status}"
+            )));
+        }
+
+        // Collect the response body (hyper strips chunked framing).
+        let body_bytes = response
+            .into_body()
+            .collect()
+            .await
+            .map_err(|e| JsValue::from_str(&format!("reattestation failed: {e}")))?
+            .to_bytes();
+        drop(sender_guard);
+
+        // No RefCell borrow is held across this await (Reattester is &self).
+        let report = self
+            .reattester
+            .finish(&request, &body_bytes)
+            .await
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+        let summary = summarize(&report);
+        *self.attestation.borrow_mut() = summary.clone();
+        serde_wasm_bindgen::to_value(&summary).map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
     /// Check if the connection is ready for another request.

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -339,28 +339,59 @@ impl AtlsHttp {
     /// this session). The connection must be idle — check `isReady()` first,
     /// like `fetch()`.
     ///
-    /// On success the stored attestation is refreshed and returned. On
-    /// failure the evidence stays stale and the connection must be closed
-    /// and replaced (fail closed); a fresh connect performs a full
-    /// attestation.
+    /// The connection is unavailable for the *entire* exchange, appraisal
+    /// included: `isReady()` reports false and concurrent `fetch()` calls
+    /// fail until the fresh evidence is fully verified, so no application
+    /// data can ride the connection on unverified evidence.
+    ///
+    /// On success the stored attestation is refreshed and returned. On any
+    /// failure the evidence stays stale and the connection is closed
+    /// (fail closed, enforced here — not delegated to the caller); a fresh
+    /// connect performs a full attestation.
     #[wasm_bindgen(js_name = reattest)]
     pub async fn reattest(&self) -> Result<JsValue, JsValue> {
-        let request = self.reattester.begin();
-        let body_json = request.body_json();
-
-        // Mirrors fetch(): the sender borrow is held for the exchange, so a
-        // concurrent fetch()/reattest() is serialized by the JS caller via
-        // isReady(), exactly like concurrent fetch()+fetch().
-        let mut sender_guard = self.sender.borrow_mut();
-        let sender = sender_guard
-            .as_mut()
-            .ok_or_else(|| JsValue::from_str("connection closed"))?;
+        // Take the sender for the whole exchange so the connection cannot be
+        // used until appraisal completes.
+        let taken = self.sender.borrow_mut().take();
+        let mut sender = match taken {
+            Some(sender) => sender,
+            None => {
+                return Err(JsValue::from_str(
+                    "connection unavailable (closed or re-attestation in progress)",
+                ))
+            }
+        };
 
         if !sender.is_ready() {
+            // Busy with an in-flight response — not broken: restore untouched.
+            *self.sender.borrow_mut() = Some(sender);
             return Err(JsValue::from_str(
                 "connection busy - wait for previous response to complete",
             ));
         }
+
+        match self.reattest_exchange(&mut sender).await {
+            Ok(summary_js) => {
+                // Only fully appraised connections become available again.
+                *self.sender.borrow_mut() = Some(sender);
+                Ok(summary_js)
+            }
+            Err(e) => {
+                // Fail closed: dropping the sender ends the hyper connection.
+                drop(sender);
+                Err(e)
+            }
+        }
+    }
+
+    /// The `/tdx_quote` exchange + appraisal, with the sender held exclusively
+    /// by the caller ([`reattest`](Self::reattest) removed it from `self`).
+    async fn reattest_exchange(
+        &self,
+        sender: &mut SendRequest<Full<Bytes>>,
+    ) -> Result<JsValue, JsValue> {
+        let request = self.reattester.begin();
+        let body_json = request.body_json();
 
         let http_request = Request::builder()
             .method(ReattestRequest::method())
@@ -390,7 +421,6 @@ impl AtlsHttp {
             .await
             .map_err(|e| JsValue::from_str(&format!("reattestation failed: {e}")))?
             .to_bytes();
-        drop(sender_guard);
 
         // No RefCell borrow is held across this await (Reattester is &self).
         // `finish` consumes the request: this exchange cannot be replayed.
@@ -662,5 +692,189 @@ mod tests {
 
         let json = serde_json::to_string(&summary).unwrap();
         assert!(json.contains("\"advisoryIds\":[]"));
+    }
+
+    // ------------------------------------------------------------------
+    // Re-attestation state-machine tests: a real hyper connection over an
+    // in-memory duplex, fully offline.
+    // ------------------------------------------------------------------
+
+    use futures::channel::{mpsc, oneshot};
+    use futures::stream::Stream;
+    use futures::task::{Context, Poll};
+    use std::pin::Pin;
+
+    /// Minimal in-memory duplex implementing the futures I/O traits.
+    struct TestDuplex {
+        rx: mpsc::UnboundedReceiver<Vec<u8>>,
+        tx: mpsc::UnboundedSender<Vec<u8>>,
+        pending: Vec<u8>,
+    }
+
+    fn duplex_pair() -> (TestDuplex, TestDuplex) {
+        let (tx_a, rx_a) = mpsc::unbounded();
+        let (tx_b, rx_b) = mpsc::unbounded();
+        (
+            TestDuplex {
+                rx: rx_b,
+                tx: tx_a,
+                pending: Vec::new(),
+            },
+            TestDuplex {
+                rx: rx_a,
+                tx: tx_b,
+                pending: Vec::new(),
+            },
+        )
+    }
+
+    impl futures::io::AsyncRead for TestDuplex {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<std::io::Result<usize>> {
+            if self.pending.is_empty() {
+                match Pin::new(&mut self.rx).poll_next(cx) {
+                    Poll::Ready(Some(chunk)) => self.pending = chunk,
+                    Poll::Ready(None) => return Poll::Ready(Ok(0)),
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
+            let n = self.pending.len().min(buf.len());
+            buf[..n].copy_from_slice(&self.pending[..n]);
+            self.pending.drain(..n);
+            Poll::Ready(Ok(n))
+        }
+    }
+
+    impl futures::io::AsyncWrite for TestDuplex {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            let _ = self.tx.unbounded_send(buf.to_vec());
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            self.tx.close_channel();
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn test_reattester() -> Reattester {
+        let mut policy = atlas_rs::DstackTdxPolicy::dev();
+        policy.reattestation_interval_secs = 300;
+        let verifier = atlas_rs::Policy::DstackTdx(policy).into_verifier().unwrap();
+        Reattester::new(
+            verifier,
+            b"peer-cert-der".to_vec(),
+            vec![0u8; 32],
+            "tee.test".to_string(),
+        )
+    }
+
+    /// Read one HTTP request (headers + Content-Length body) from the stream.
+    async fn read_http_request(io: &mut TestDuplex) -> String {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 1024];
+        loop {
+            let n = io.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "client closed while sending request");
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                let headers = String::from_utf8_lossy(&buf[..pos]).to_string();
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.to_ascii_lowercase()
+                            .strip_prefix("content-length:")
+                            .map(|v| v.trim().parse::<usize>().unwrap())
+                    })
+                    .unwrap_or(0);
+                if buf.len() >= pos + 4 + content_length {
+                    return String::from_utf8(buf).unwrap();
+                }
+            }
+        }
+    }
+
+    /// The connection must be unavailable (isReady() == false) for the whole
+    /// re-attestation exchange — appraisal included — and closed after a
+    /// failed appraisal, enforced in Rust rather than by the JS caller.
+    #[wasm_bindgen_test]
+    async fn test_reattest_unavailable_during_exchange_and_fails_closed() {
+        let (client_io, mut server_io) = duplex_pair();
+
+        let (mut sender, conn) = http1::handshake(HyperIo::new(client_io)).await.unwrap();
+        wasm_bindgen_futures::spawn_local(async move {
+            let _ = conn.await;
+        });
+        // Readiness is driven by the connection task; wait for the first poll.
+        sender.ready().await.unwrap();
+
+        let http = Rc::new(AtlsHttp {
+            sender: Rc::new(RefCell::new(Some(sender))),
+            attestation: RefCell::new(AttestationSummary {
+                trusted: true,
+                tee_type: "Tdx".to_string(),
+                tcb_status: "UpToDate".to_string(),
+                advisory_ids: vec![],
+            }),
+            reattester: Rc::new(test_reattester()),
+        });
+
+        assert!(http.is_ready(), "fresh connection must be ready");
+
+        let (done_tx, done_rx) = oneshot::channel();
+        {
+            let http = http.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let result = http.reattest().await;
+                let _ = done_tx.send(result.is_err());
+            });
+        }
+
+        // Act as the attester: receive the full quote request while
+        // withholding the response.
+        let request = read_http_request(&mut server_io).await;
+        assert!(request.starts_with("POST /tdx_quote HTTP/1.1\r\n"));
+
+        // The exchange (and the appraisal that follows the response) has not
+        // completed: the connection must be unavailable so no application
+        // request can ride unverified evidence.
+        assert!(
+            !http.is_ready(),
+            "connection must be unavailable during re-attestation"
+        );
+
+        // Respond 200 with an empty event log: appraisal fails offline at
+        // the certificate check, before any network access.
+        let body = serde_json::json!({
+            "quote": {"quote": "", "event_log": "[]", "report_data": "", "vm_config": ""}
+        })
+        .to_string();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        server_io.write_all(response.as_bytes()).await.unwrap();
+        server_io.flush().await.unwrap();
+
+        let failed = done_rx.await.unwrap();
+        assert!(failed, "appraisal of an empty event log must fail");
+
+        // Fail closed: the failed connection stays unusable.
+        assert!(
+            !http.is_ready(),
+            "connection must be closed after failed re-attestation"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Atlas previously performed attestation exactly once, at connection establishment, leaving a window in which workload/platform state changes on the attester go unnoticed for the lifetime of the connection — particularly concerning for long-lived connections and streaming workloads.

FIXES #18 

This PR adds **transparent, in-band re-attestation** of established connections across all client surfaces (Rust core, Node, Python, browser/WASM), configurable via a single policy field:

```jsonc
{ "type": "dstack_tdx", "reattestation_interval_secs": 300, ... }
```

- **Default: 300 seconds.** Absent from the policy JSON ⇒ default applies everywhere.
- **`0` disables re-attestation completely** (restores previous behavior exactly: no timers armed, no checks).
- Non-zero values below 30 s are rejected by `validate()` to protect attesters from quote-generation storms.

## Design

**Guarantee:** no request is dispatched on a connection whose attestation evidence is older than the configured interval.

**Each re-attestation carries the same security weight as the initial attestation.** It re-runs the *full* verification pipeline — `/tdx_quote` exchange, DCAP verification, `report_data` check, RTMR replay, bootchain / app-compose / OS-image checks — with a **fresh nonce** bound to the **same session EKM** (`report_data = SHA512(nonce || session_ekm)`). The fresh nonce provides evidence freshness; the EKM (a secret that never leaves the TLS endpoints and is not exposed by earlier rounds) binds the fresh evidence to *this* live session (RFC 9266 channel binding). The one intentional difference: the session certificate may match *any* `New TLS Certificate` event in the log rather than only the latest (`CertEventMatch::Any`), because a mid-session certificate rotation on the attester appends a new event to the append-only, RTMR-replay-protected log while the session certificate stays valid.

**No background timers.** Staleness is checked lazily at safe message boundaries (no request/response in flight), so the interval is the *maximum evidence age at the moment the connection is used* — a connection idle for an hour is re-verified right before its next request. This also keeps core free of new runtime dependencies (no tokio `time`/`sync` in core, no wasm timers).

**Fail-closed.** A failed re-attestation never refreshes the evidence age; the connection is torn down and never reused. Pooled surfaces transparently open a fresh connection, which always performs a full attestation; if the workload is genuinely bad, that fresh connect fails too and the error surfaces through the existing connect error path.

### Per-surface integration

| Surface | Mechanism |
|---|---|
| **Rust core** | New `atls_connect_with_reattester()` returns a `Reattester` (retains verifier + peer cert + session EKM; no `Debug` impl so the EKM cannot leak into logs). `is_due()` / `reattest(&mut stream)` for raw streams; `begin()`/`finish()` for transports that own the stream. `atls_connect` is unchanged (thin wrapper). |
| **Node (Bun fetch path)** | Pool re-attests reused connections in-band at acquire (quiescent by construction) via new native `socketReattestIfDue` — holds both half-locks, recombines them with `tokio::io::join`, re-checks due-ness under the locks, 30 s timeout. |
| **Node (`https.Agent` path)** | In-band injection is unsound here (Node's HTTP machinery keeps a read pending on pooled sockets), so expired sockets are **retired**: `keepSocketAlive` refuses to pool them and an unref'd timer destroys ones that expire while idle; the next request reconnects with full attestation. Same guarantee. |
| **Python (httpx transport)** | The first `write()` after a `read()` marks a message boundary (sync httpcore never interleaves within a message); the native layer re-attests there when due. Failure raises the new `atlas.ReattestationError`. `response.extensions["attestation"]` always reflects the latest verification. |
| **WASM (`AtlsHttp` / `createAtlsFetch`)** | EKM/cert captured before hyper consumes the stream; `reattest()` sends `/tdx_quote` through the live hyper connection and appraises the body via the new fetch/appraise verifier split. `createAtlsFetch` drives it transparently on cache reuse. `AttestedStream` documents re-attestation as caller-owned (it cannot know the app's framing). |

### Also included

- `perf(core)`: the collateral cache is now **process-global** (was per-verifier-instance, so every new connection refetched from PCCS even with `cache_collateral: true`).
- New error variant `AtlsVerificationError::Reattestation { source }`; Python `ReattestationError`.
- Typings/docs: `reattestation_interval_secs` in Node/WASM `.d.ts`, Python `dstack_tdx_policy(...)` kwarg and `.pyi`; core README/ARCHITECTURE sections, binding READMEs, SECURITY.md invariants + limitations.
- Fixed pre-existing gaps in `wasm/src/atls-fetch.d.ts` (missing required `policy`, missing `advisoryIds`).

## Behavior changes to announce

- **Re-attestation is ON by default (300 s) for all bindings.** Opt out with `reattestation_interval_secs: 0`.
- `onAttestation` now fires on every re-attestation/reconnect, not only the first connect.
- Documented limitations (SECURITY.md): a single response streaming longer than the interval is not interrupted mid-flight (re-checked at the next boundary); the residual window between re-attestations remains; quotes cannot reveal unmeasured runtime memory modification.

## Testing

- **Core (43 lib tests)**: duplex-scripted exchange tests (request framing, `Host`/`Content-Length`, 64-hex nonce, fresh nonce per cycle, fragmented responses, EOF ⇒ `Reattestation{Io}` with evidence still stale, fail-closed appraisal), `CertEventMatch::Latest` vs `Any` (rotation scenario, malformed payloads strict in both modes), due-math and `is_due` lifecycle, policy serde (absent ⇒ 300, `0` roundtrip, 1–29 rejected), global collateral cache TTL/key isolation.
- **Node (24 tests)**: `tokio::io::join`-over-locked-halves roundtrip; Agent retirement predicates (expired/flagged/fresh, interval-0 ⇒ `Infinity` deadline); pool re-attest success/skip/failure paths via injected deps.
- **Python (46 tests, 99% coverage, `qa-all` clean)**: policy kwarg present/absent/zero; `ReattestationError` exports.
- **WASM**: `cargo check` for `wasm32` (both cfg variants) + `wasm-pack test --node`.
- One new `#[ignore]`d live e2e (`test_reattest_live_connection`) alongside the existing ones, for when a live enclave is available again.

Full verification suite passes: `make test`, `make test-wasm`, `cargo fmt --all --check`, `cargo clippy --workspace --exclude atlas-wasm`, `make build-node && make test-node`, `cd python && make test && make qa-all`, `make build-wasm && make test-wasm-node`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)